### PR TITLE
Bugs valgrind

### DIFF
--- a/src/qalloc.c
+++ b/src/qalloc.c
@@ -297,6 +297,8 @@ void *qalloc_makedynmap(const off_t  filesize,
         /* initialize the use bitmap */
         memset(mi->bitmap, 0, mi->bitmaplength);
         qassert(pthread_mutex_init(mi->bitmap_lock, NULL), 0);
+        mi->next = dynmmaps;
+        dynmmaps = mi;
         return mi;
     } else if (set != ret) {
         /* asked for it somewhere that it didn't appear */

--- a/test/basics/hello_world_multi.c
+++ b/test/basics/hello_world_multi.c
@@ -44,6 +44,8 @@ int main(int   argc,
         assert(ret == QTHREAD_SUCCESS);
     }
 
+    free(rets);
+
     return EXIT_SUCCESS;
 }
 

--- a/test/basics/qtimer.c
+++ b/test/basics/qtimer.c
@@ -6,7 +6,7 @@
 #include <math.h> /* for sqrt() */
 #include "argparsing.h"
 
-unsigned int ITER = 100;
+const unsigned int ITER = 100;
 
 static int dcmp(const void *a,
                 const void *b)

--- a/test/basics/queue.c
+++ b/test/basics/queue.c
@@ -101,7 +101,7 @@ int main(int   argc,
     assert(qthread_readstate(NODE_BUSYNESS) == 1);
 
     iprintf("6/6 Test passed!\n");
-
+    free(retvals);
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
I found several minor bugs while playing with the code base and valgrind. Most of these are extremely minor and were just used to remove warnings, etc. However, please pay special attention to 7860a17a335db7cd4bf176137bf6882ca1bbe7f3.

That path through the code allowed for that memory to never be released. I believe this corrects that the issue.