### PR TITLE
Add aligned writeff

### DIFF
--- a/include/qt_addrstat.h
+++ b/include/qt_addrstat.h
@@ -17,6 +17,7 @@ static QINLINE qthread_addrstat_t *qthread_addrstat_new(void)
         ret->EFQ   = NULL;
         ret->FEQ   = NULL;
         ret->FFQ   = NULL;
+        ret->FFWQ  = NULL;
         QTHREAD_EMPTY_TIMER_INIT(ret);
     }
     return ret;

--- a/include/qt_blocking_structs.h
+++ b/include/qt_blocking_structs.h
@@ -49,6 +49,7 @@ typedef struct qthread_addrstat_s {
     qthread_addrres_t    *EFQ;
     qthread_addrres_t    *FEQ;
     qthread_addrres_t    *FFQ;
+    qthread_addrres_t    *FFWQ;
 #ifdef QTHREAD_FEB_PROFILING
     qtimer_t              empty_timer;
 #endif

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -487,6 +487,22 @@ int qthread_syncvar_writeF(syncvar_t *restrict      dest,
 int qthread_syncvar_writeF_const(syncvar_t *restrict dest,
                                  uint64_t            src);
 
+/* This function waits for memory to become full, and leaves it full. When
+ * memory becomes full, all threads waiting for it to become full with a
+ * writeFF will write their value and be queued to run. Data is read from src
+ * and written to dest.
+
+ *
+ * The semantics of writeFF are:
+ * 1 - destination's FEB state must be "full"
+ * 2 - data is copied from src to destination
+ */
+int qthread_writeFF(aligned_t *restrict       dest,
+                    const aligned_t *restrict src);
+int qthread_writeFF_const(aligned_t *dest,
+                          aligned_t  src);
+// NOTE: There is no syncvar version of writeFF or writeFF_const
+
 /* This function waits for memory to become full, and then reads it and leaves
  * the memory as full. When memory becomes full, all threads waiting for it to
  * become full with a readFF will receive the value at once and will be queued

--- a/src/feb.c
+++ b/src/feb.c
@@ -327,7 +327,7 @@ got_m:
             qthread_debug(FEB_DETAILS, "maddr=%p: addrstat invalid; someone else invalidated it!\n", maddr);
             return;
         }
-        if ((m->FEQ == NULL) && (m->EFQ == NULL) && (m->FFQ == NULL) &&
+        if ((m->FEQ == NULL) && (m->EFQ == NULL) && (m->FFQ == NULL) && (m->FFWQ == NULL) &&
             (m->full == 1)) {
             qthread_debug(FEB_DETAILS, "maddr=%p: lists are empty, status is full; invalidating and removing (m:%p)\n", maddr, m);
             m->valid = 0;
@@ -343,7 +343,7 @@ got_m:
         m = (qthread_addrstat_t *)qt_hash_get_locked(FEBs[lockbin], maddr);
         if (m) {
             QTHREAD_FASTLOCK_LOCK(&(m->lock));
-            if ((m->FEQ == NULL) && (m->EFQ == NULL) && (m->FFQ == NULL) &&
+            if ((m->FEQ == NULL) && (m->EFQ == NULL) && (m->FFQ == NULL) && (m->FFWQ == NULL) &&
                 (m->full == 1)) {
                 qthread_debug(FEB_DETAILS, "maddr=%p: lists are empty, status is full; invalidating and removing\n", maddr);
                 qassertnot(qt_hash_remove_locked(FEBs[lockbin], maddr), 0);
@@ -420,7 +420,7 @@ static QINLINE void qthread_gotlock_empty_inner(qthread_shepherd_t *shep,
         FREE_ADDRRES(X);
         qthread_gotlock_fill_inner(shep, m, maddr, 1, precond_tasks);
     }
-    if ((m->full == 1) && (m->EFQ == NULL) && (m->FEQ == NULL) && (m->FFQ == NULL)) {
+    if ((m->full == 1) && (m->EFQ == NULL) && (m->FEQ == NULL) && (m->FFQ == NULL) && (m->FFWQ == NULL)) {
         removeable = 1;
     } else {
         removeable = 0;
@@ -459,19 +459,20 @@ static QINLINE void qthread_gotlock_fill_inner(qthread_shepherd_t *shep,
     assert(maddr);
     m->full = 1;
     QTHREAD_EMPTY_TIMER_STOP(m);
-    /* dequeue all FFQ, do their operation, and schedule them */
-    while (m->FFQ != NULL) {
+    /* dequeue all FFWQ, do their operation, and schedule them */
+    // TODO could be optimized to only perform the last operation
+    while (m->FFWQ != NULL) {
         /* dQ */
-        X      = m->FFQ;
-        m->FFQ = X->next;
+        X       = m->FFWQ;
+        m->FFWQ = X->next;
         /* op */
-        if (X->addr && (X->addr != maddr)) {
-            *(aligned_t *)(X->addr) = *(aligned_t *)maddr;
+        if (maddr && (maddr != X->addr)) {
+            *(aligned_t *)maddr = *(X->addr);
             MACHINE_FENCE;
         }
         /* schedule */
         qthread_t *waiter = X->waiter;
-        qthread_debug(FEB_DETAILS, "shep(%u), m(%p), maddr(%p), recursive(%u): dQ one from FFQ (%u releasing tid %u with %u)\n", shep->shepherd_id, m, maddr, recursive, qthread_id(), waiter->thread_id, *(aligned_t *)maddr);
+        qthread_debug(FEB_DETAILS, "shep(%u), m(%p), maddr(%p), recursive(%u): dQ one from FFWQ (%u releasing tid %u with %u)\n", shep->shepherd_id, m, maddr, recursive, qthread_id(), waiter->thread_id, *(aligned_t *)maddr);
         if (QTHREAD_STATE_NASCENT == waiter->thread_state) {
             if (*precond_tasks == NULL) {
                 /* create empty head to avoid later checks/branches; use the waiter to find the tail */
@@ -491,6 +492,32 @@ static QINLINE void qthread_gotlock_fill_inner(qthread_shepherd_t *shep,
              * thus avoiding a possible dead-lock but having to launch all
              * sequentially after releasing the lock. On the plus side,
              * all tasks present in the ready queue (or cache) are ready to run.*/
+            ((qthread_addrres_t *)((*precond_tasks)->waiter))->next = X;
+            (*precond_tasks)->waiter                                = (void *)X;
+        } else {
+            qt_feb_schedule(waiter, shep);
+            FREE_ADDRRES(X);
+        }
+    }
+    /* dequeue all FFQ, do their operation, and schedule them */
+    while (m->FFQ != NULL) {
+        /* dQ */
+        X      = m->FFQ;
+        m->FFQ = X->next;
+        /* op */
+        if (X->addr && (X->addr != maddr)) {
+            *(aligned_t *)(X->addr) = *(aligned_t *)maddr;
+            MACHINE_FENCE;
+        }
+        /* schedule */
+        qthread_t *waiter = X->waiter;
+        qthread_debug(FEB_DETAILS, "shep(%u), m(%p), maddr(%p), recursive(%u): dQ one from FFQ (%u releasing tid %u with %u)\n", shep->shepherd_id, m, maddr, recursive, qthread_id(), waiter->thread_id, *(aligned_t *)maddr);
+        if (QTHREAD_STATE_NASCENT == waiter->thread_state) {
+            if (*precond_tasks == NULL) {
+                /* create empty head to avoid later checks/branches; use the waiter to find the tail */
+                *precond_tasks           = ALLOC_ADDRRES();
+                (*precond_tasks)->waiter = (void *)(*precond_tasks);
+            }
             ((qthread_addrres_t *)((*precond_tasks)->waiter))->next = X;
             (*precond_tasks)->waiter                                = (void *)X;
         } else {
@@ -1453,12 +1480,13 @@ static void qt_feb_call_tf(const qt_key_t      addr,
     if (sync) {
         QTHREAD_FASTLOCK_LOCK(&m->lock);
     }
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 4; i++) {
         qthread_addrres_t *curs, **base;
         switch (i) {
-            case 0: curs = m->EFQ; base = &m->EFQ; break;
-            case 1: curs = m->FEQ; base = &m->FEQ; break;
-            case 2: curs = m->FFQ; base = &m->FFQ; break;
+            case 0: curs = m->EFQ;  base = &m->EFQ;  break;
+            case 1: curs = m->FEQ;  base = &m->FEQ;  break;
+            case 2: curs = m->FFQ;  base = &m->FFQ;  break;
+            case 3: curs = m->FFWQ; base = &m->FFWQ; break;
         }
         for (; curs != NULL; curs = curs->next) {
             qthread_t *waiter = curs->waiter;

--- a/test/basics/Makefile.am
+++ b/test/basics/Makefile.am
@@ -8,6 +8,8 @@
 TESTS = \
 		hello_world \
 		aligned_prodcons \
+		aligned_writeFF_basic \
+		aligned_writeFF_waits \
 		hello_world_multi \
 		syncvar_prodcons \
 		reinitialization \
@@ -63,6 +65,10 @@ LDADD = $(qthreadlib)
 hello_world_SOURCES = hello_world.c
 
 aligned_prodcons_SOURCES = aligned_prodcons.c
+
+aligned_writeFF_basic_SOURCES = aligned_writeFF_basic.c
+
+aligned_writeFF_waits_SOURCES = aligned_writeFF_waits.c
 
 hello_world_multi_SOURCES = hello_world_multi.c
 

--- a/test/basics/aligned_writeFF_basic.c
+++ b/test/basics/aligned_writeFF_basic.c
@@ -1,0 +1,79 @@
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <unistd.h>
+#include <qthread/qthread.h>
+#include "argparsing.h"
+
+// Test that a writeFF on a full var performs the write, and leaves the FEB
+// state untouched. 
+static void testBasicWriteFF(void) 
+{
+    aligned_t x, val;
+
+    x = 45, val = 55;
+    assert(qthread_feb_status(&x) == 1);
+
+    iprintf("Before x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+    qthread_writeFF(&x, &val);
+    iprintf("After  x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+
+    assert(qthread_feb_status(&x) == 1);
+    assert(x == 55);
+    assert(val == 55);
+}
+
+#define ALL_ONES  ~0u
+#define ALL_ZEROS 0
+#define ITERS_PER_WORKER 10000
+
+static aligned_t concurrent_t;
+static aligned_t alignedWriteFF_iters(void *arg)
+{
+    aligned_t v = (aligned_t)(intptr_t)arg;
+    for(int i=0; i<ITERS_PER_WORKER; i++) {
+        qthread_writeFF_const(&concurrent_t, v);
+    }
+    return 0;
+}
+
+// Test that concurrent writeFFs work and that no tearing occurs
+static void testConcurrentWriteFF(void)
+{
+    int num_writers = (int)qthread_num_workers()/2;
+    aligned_t rets[num_writers*2];
+    concurrent_t = 0;
+    qthread_fill(&concurrent_t);
+    
+
+    for (int i=0; i<num_writers; i++) {
+      qthread_fork(alignedWriteFF_iters, (void*)ALL_ZEROS, &rets[i]);
+      qthread_fork(alignedWriteFF_iters, (void*)ALL_ONES, &rets[i+num_writers]);
+    }
+
+    for (int i=0; i<num_writers*2; i++) {
+      qthread_readFF(&rets[i], &rets[i]);
+    }
+
+    iprintf("concurrent_t=%x\n", concurrent_t);
+    assert((concurrent_t == ALL_ZEROS) || (concurrent_t == ALL_ONES));
+    assert(qthread_feb_status(&concurrent_t) == 1);
+}
+
+int main(int argc,
+         char *argv[])
+{
+    CHECK_VERBOSE();
+    assert(qthread_initialize() == 0);
+    iprintf("%i shepherds...\n", qthread_num_shepherds());
+    iprintf("  %i threads total\n", qthread_num_workers());
+
+    testBasicWriteFF();
+    testConcurrentWriteFF();
+}
+
+/* vim:set expandtab */

--- a/test/basics/aligned_writeFF_waits.c
+++ b/test/basics/aligned_writeFF_waits.c
@@ -1,0 +1,73 @@
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <unistd.h>
+#include <qthread/qthread.h>
+#include "argparsing.h"
+
+static aligned_t concurrent_t;
+static aligned_t writeFF_wrapper(void *arg)
+{
+    iprintf("2: writeFF wrapper started\n");
+    qthread_writeFF_const(&concurrent_t, 55);
+    iprintf("2: writeFF completed\n");
+    return 0;
+}
+
+// Test that writeFF waits for empty var to be filled, writes, and leaves full.
+// Requires that only one worker is running. Basically does:
+//     1: empty var
+//     1: fork(writeFF)
+//     1: yields
+//     2: starts runnning
+//     2: hits writeFF, and yields since var is empty
+//     1: writeEF
+//     1: hits readFF on forked task and yield
+//     2: running again, finishes writeFF, task returns
+//     1: readFF competes, finishes
+static void testWriteFFWaits(void)
+{
+    aligned_t ret;
+    concurrent_t=45;
+    qthread_empty(&concurrent_t);
+    assert(qthread_num_workers() == 1);
+
+    iprintf("1: Forking writeFF wrapper\n");
+    qthread_fork_to(writeFF_wrapper, NULL, &ret, qthread_shep());
+    iprintf("1: Forked, now yielding to 2\n");
+    qthread_yield();
+    iprintf("1: Back from yield\n");
+
+    // verify that writeFF has not completed
+    assert(qthread_feb_status(&concurrent_t) == 0);
+    assert(concurrent_t != 55);
+
+    iprintf("1: Writing EF\n");
+    qthread_writeEF_const(&concurrent_t, 35);
+
+    // wait for writeFF wrapper to complete
+    qthread_readFF(NULL, &ret);
+
+    // veify that writeFF completed and that FEB is full
+    iprintf("1: concurrent_t=%d\n", concurrent_t);
+    assert(qthread_feb_status(&concurrent_t) == 1);
+    assert(concurrent_t == 55);
+}
+
+
+int main(int argc,
+         char *argv[])
+{
+    CHECK_VERBOSE();
+    assert(qthread_init(1) == 0); 
+    iprintf("%i shepherds...\n", qthread_num_shepherds());
+    iprintf("  %i threads total\n", qthread_num_workers());
+
+    testWriteFFWaits();
+}
+
+/* vim:set expandtab */


### PR DESCRIPTION
This adds support for writeFF on aligned (but not syncvar_t) FEB vars

In order to support writeFF I basically:
 - added a new FEB queue called FFWQ (full full writers (aka writeFF) queue)
 - cloned readFF to writeFF since the hash locking/unlocking and when we can
   read/write is similar
 - updated writeFF to
    - use a WRITEFF blocker_type
    - use dest instead of src for lockbin, alignedaddr, and x->addr
    - use FFWQ instead of FFQ

Note that when an empty FEB is filled, the current implemenation performs all
writeFF operations first, and then continues onto the existing readFF
operations.

This also adds some writeFF tests to check that:
 - writeFF on a full var writes, and leaves the FEB full
 - concurrent writeFFs work without tearing
 - writeFF on an empty var blocks until filled, then writes, and leaves full

Note that I did not add writeFF for the syncvar_t FEB type, and I don't have
any plans to do so. This is being added because we want to map Chapel sync vars
down to native qthread syncvars and we need the full 64 bits so we can't use
the inline FEBs.

writeE and readXX are still needed in order to map Chapel Sync vars down. I
plan on adding those shortly, but I split writeFF off to simplify review.
https://github.com/Qthreads/qthreads/issues/22 has more info on the missing FEB
operations.
