### PR TITLE
Add aligned writeE

### DIFF
--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -487,6 +487,21 @@ int qthread_syncvar_writeF(syncvar_t *restrict      dest,
 int qthread_syncvar_writeF_const(syncvar_t *restrict dest,
                                  uint64_t            src);
 
+/* This function is a cross between qthread_empty() and qthread_writeEF(). It
+ * does not wait for memory to become empty, but performs the write and sets
+ * the state to empty atomically with respect to other FEB-based actions. Data
+ * is read from src and written to dest.
+ *
+ * The semantics of writeE are:
+ * 1 - data is copied from src to destination
+ * 2 - the destination's FEB state gets set to empty
+ */
+int qthread_writeE(aligned_t *restrict       dest,
+                   const aligned_t *restrict src);
+int qthread_writeE_const(aligned_t *dest,
+                         aligned_t  src);
+// NOTE: There is no syncvar version of writeE or writeE_const
+
 /* This function waits for memory to become full, and leaves it full. When
  * memory becomes full, all threads waiting for it to become full with a
  * writeFF will write their value and be queued to run. Data is read from src

--- a/test/basics/Makefile.am
+++ b/test/basics/Makefile.am
@@ -8,6 +8,8 @@
 TESTS = \
 		hello_world \
 		aligned_prodcons \
+		aligned_writeE_basic \
+		aligned_writeE_wakes \
 		aligned_writeFF_basic \
 		aligned_writeFF_waits \
 		hello_world_multi \
@@ -65,6 +67,10 @@ LDADD = $(qthreadlib)
 hello_world_SOURCES = hello_world.c
 
 aligned_prodcons_SOURCES = aligned_prodcons.c
+
+aligned_writeE_basic_SOURCES = aligned_writeE_basic.c
+
+aligned_writeE_wakes_SOURCES = aligned_writeE_wakes.c
 
 aligned_writeFF_basic_SOURCES = aligned_writeFF_basic.c
 

--- a/test/basics/aligned_writeE_basic.c
+++ b/test/basics/aligned_writeE_basic.c
@@ -1,0 +1,60 @@
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <unistd.h>
+#include <qthread/qthread.h>
+#include "argparsing.h"
+
+// Test that a writeE on a full var performs the write, and changes the FEB
+// state to empty.
+static void testWriteEOnFull(void)
+{
+    aligned_t x, val;
+
+    x = 45, val = 55;
+    assert(qthread_feb_status(&x) == 1);
+
+    iprintf("Before x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+    qthread_writeE(&x, &val);
+    iprintf("After  x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+
+    assert(qthread_feb_status(&x) == 0);
+    assert(x == 55);
+    assert(val == 55);
+}
+
+// Test that a writeE on an empty var performs the write, and leaves the FEB
+// state unchanged
+static void testWriteEOnEmpty(void)
+{
+    aligned_t x, val;
+
+    x = 45, val = 55;
+    qthread_empty(&x);
+
+    iprintf("Before x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+    qthread_writeE(&x, &val);
+    iprintf("After  x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+
+    assert(qthread_feb_status(&x) == 0);
+    assert(x == 55);
+    assert(val == 55);
+}
+
+int main(int argc,
+         char *argv[])
+{
+    CHECK_VERBOSE();
+    assert(qthread_initialize() == 0);
+    iprintf("%i shepherds...\n", qthread_num_shepherds());
+    iprintf("  %i threads total\n", qthread_num_workers());
+
+    testWriteEOnFull();
+    testWriteEOnEmpty();
+}
+
+/* vim:set expandtab */

--- a/test/basics/aligned_writeE_wakes.c
+++ b/test/basics/aligned_writeE_wakes.c
@@ -1,0 +1,71 @@
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <unistd.h>
+#include <qthread/qthread.h>
+#include "argparsing.h"
+
+static aligned_t concurrent_t;
+static aligned_t writeEF_wrapper(void *arg)
+{
+    iprintf("2: writeEF wrapper started\n");
+    qthread_writeEF_const(&concurrent_t, 55);
+    iprintf("2: writeEF completed\n");
+    return 0;
+}
+
+// Test that writeE wakes a blocked writeEF
+// Requires that only one worker is running. Basically does:
+//     1: fork(writeE)
+//     1: yields
+//     2: starts runnning
+//     2: hits writeEF, and yields since var is full
+//     1: writeE
+//     1: hits readFF on forked task and yields
+//     2: running again, finishes writeEF, task returns
+//     1: readFF competes, finishes
+static void testWriteEWakes(void)
+{
+    aligned_t ret;
+    concurrent_t=45;
+    assert(qthread_num_workers() == 1);
+
+    iprintf("1: Forking writeEF wrapper\n");
+    qthread_fork_to(writeEF_wrapper, NULL, &ret, qthread_shep());
+    iprintf("1: Forked, now yielding to 2\n");
+    qthread_yield();
+    iprintf("1: Back from yield\n");
+
+    // verify that writeEF has not completed
+    assert(qthread_feb_status(&concurrent_t) == 1);
+    assert(concurrent_t != 55);
+
+    iprintf("1: Writing E\n");
+    qthread_writeE_const(&concurrent_t, 35);
+
+    // wait for writeEF wrapper to complete
+    qthread_readFF(NULL, &ret);
+
+    // veify that writeEF completed and that FEB is full
+    iprintf("1: concurrent_t=%d\n", concurrent_t);
+    assert(qthread_feb_status(&concurrent_t) == 1);
+    assert(concurrent_t == 55);
+}
+
+
+int main(int argc,
+         char *argv[])
+{
+    CHECK_VERBOSE();
+    assert(qthread_init(1) == 0);
+    iprintf("%i shepherds...\n", qthread_num_shepherds());
+    iprintf("  %i threads total\n", qthread_num_workers());
+
+    testWriteEWakes();
+}
+
+/* vim:set expandtab */


### PR DESCRIPTION
This adds support for writeE on aligned (but not syncvar_t) FEB vars

In order to support writeE I basically cloned qthread_empty since the hash
locking/unlocking is the same, and added a write after the locking logic.

This also adds some writeE tests to check that:
 - writeE on a full var writes, and empties the FEB
 - writeE on an empty var writes, and leaves the FEB empty
 - writeE on a full var wakes a blocked writeEF
