### PR TITLE
Add aligned readXX

### DIFF
--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -546,6 +546,17 @@ int qthread_readFE(aligned_t       *dest,
 int qthread_syncvar_readFE(uint64_t *restrict  dest,
                            syncvar_t *restrict src);
 
+/* This function ignores the FEB state. Data is read from src and written to
+ * dest.
+ *
+ * The semantics of readXX are:
+ * 1 - src's FEB state is ignored
+ * 2 - data is copied from src to destination
+ */
+int qthread_readXX(aligned_t       *dest,
+                   const aligned_t *src);
+// NOTE: There is no syncvar version of readXX
+
 /* functions to implement FEB-ish locking/unlocking
  *
  * These are atomic and functional, but do not have the same semantics as full

--- a/src/feb.c
+++ b/src/feb.c
@@ -54,7 +54,6 @@ typedef enum bt {
     READFF,
     READFF_NB,
     READFE,
-    READXX,
     READFE_NB,
     FILL,
     EMPTY
@@ -206,9 +205,6 @@ static aligned_t qthread_feb_blocker_thread(void *arg)
             break;
         case READFF_NB:
             a->retval = qthread_readFF_nb(a->a, a->b);
-            break;
-        case READXX:
-            a->retval = qthread_readXX(a->a, a->b);
             break;
         case WRITEE:
             a->retval = qthread_writeE(a->a, a->b);
@@ -1476,19 +1472,10 @@ got_m:
 int API_FUNC qthread_readXX(aligned_t *restrict       dest,
                             const aligned_t *restrict src)
 {                      /*{{{ */
-    qthread_t          *me      = qthread_internal_self();
-
-    assert(qthread_library_initialized);
-
-    if (!me) {
-        return qthread_feb_blocker_func(dest, (void *)src, READXX);
-    }
-    qthread_debug(FEB_CALLS, "dest=%p, src=%p (tid=%i)\n", dest, src, me->thread_id);
-    QTHREAD_FEB_UNIQUERECORD(feb, src, me);
+    qthread_debug(FEB_CALLS, "dest=%p, src=%p\n", dest, src);
 
     if (dest && (dest != src)) {
         *(aligned_t *)dest = *(aligned_t *)src;
-        MACHINE_FENCE;
     }
     return QTHREAD_SUCCESS;
 }                      /*}}} */

--- a/test/basics/Makefile.am
+++ b/test/basics/Makefile.am
@@ -8,6 +8,7 @@
 TESTS = \
 		hello_world \
 		aligned_prodcons \
+		aligned_readXX_basic \
 		aligned_writeE_basic \
 		aligned_writeE_wakes \
 		aligned_writeFF_basic \
@@ -67,6 +68,8 @@ LDADD = $(qthreadlib)
 hello_world_SOURCES = hello_world.c
 
 aligned_prodcons_SOURCES = aligned_prodcons.c
+
+aligned_readXX_basic_SOURCES = aligned_readXX_basic.c
 
 aligned_writeE_basic_SOURCES = aligned_writeE_basic.c
 

--- a/test/basics/aligned_readXX_basic.c
+++ b/test/basics/aligned_readXX_basic.c
@@ -1,0 +1,60 @@
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <unistd.h>
+#include <qthread/qthread.h>
+#include "argparsing.h"
+
+// Test that a readXX on a full var performs the read, and leaves the FEB state
+// unchanged
+static void testReadXXOnFull(void)
+{
+    aligned_t x, val;
+
+    x = 45, val = 55;
+    assert(qthread_feb_status(&x) == 1);
+
+    iprintf("Before x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+    qthread_readXX(&val, &x);
+    iprintf("After  x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+
+    assert(qthread_feb_status(&x) == 1);
+    assert(x == 45);
+    assert(val == 45);
+}
+
+// Test that a readXX on an empty var performs the read, and leaves the FEB
+// state unchanged
+static void testReadXXOnEmpty(void)
+{
+    aligned_t x, val;
+
+    x = 45, val = 55;
+    qthread_empty(&x);
+
+    iprintf("Before x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+    qthread_readXX(&val, &x);
+    iprintf("After  x=%d, val=%d, x_full=%d\n", x, val, qthread_feb_status(&x));
+
+    assert(qthread_feb_status(&x) == 0);
+    assert(x == 45);
+    assert(val == 45);
+}
+
+int main(int argc,
+         char *argv[])
+{
+    CHECK_VERBOSE();
+    assert(qthread_initialize() == 0);
+    iprintf("%i shepherds...\n", qthread_num_shepherds());
+    iprintf("  %i threads total\n", qthread_num_workers());
+
+    testReadXXOnFull();
+    testReadXXOnEmpty();
+}
+
+/* vim:set expandtab */


### PR DESCRIPTION
This adds support for readXX on aligned (but not syncvar_t) FEB vars

qthread_readXX is really just a simple wrapper around:

```c
if (dest && (dest != src)) {
    *(aligned_t *)dest = *(aligned_t *)src;
}
```
