### PR TITLE
Destroy qtimer_t in sleep, usleep, and nanosleep

### DIFF
--- a/src/syscalls/nanosleep.c
+++ b/src/syscalls/nanosleep.c
@@ -38,6 +38,7 @@ int nanosleep(const struct timespec *rqtp,
             rmtp->tv_sec = rqtp->tv_sec - secs;
             rmtp->tv_nsec = (long)(qtimer_secs(t) - (double)secs) * 1e9;
         }
+        qtimer_destroy(t);
         return 0;
     } else {
 #if HAVE_SYSCALL && HAVE_DECL_SYS_NANOSLEEP

--- a/src/syscalls/sleep.c
+++ b/src/syscalls/sleep.c
@@ -29,6 +29,7 @@ unsigned int sleep(unsigned int seconds)
             qthread_yield();
             qtimer_stop(t);
         } while (qtimer_secs(t) < seconds);
+        qtimer_destroy(t);
         return 0;
     } else {
 #if HAVE_SYSCALL

--- a/src/syscalls/usleep.c
+++ b/src/syscalls/usleep.c
@@ -29,6 +29,7 @@ int usleep(useconds_t useconds)
             qthread_yield();
             qtimer_stop(t);
         } while (qtimer_secs(t) < seconds);
+        qtimer_destroy(t);
         return 0;
     } else {
 #if HAVE_SYSCALL


### PR DESCRIPTION
They were being leaked previously, so destroy them before returning