### PR TITLE
Make sure main() explicitly returns 0 in recently added FEB tests

### DIFF
--- a/test/basics/aligned_readXX_basic.c
+++ b/test/basics/aligned_readXX_basic.c
@@ -55,6 +55,8 @@ int main(int argc,
 
     testReadXXOnFull();
     testReadXXOnEmpty();
+
+    return 0;
 }
 
 /* vim:set expandtab */

--- a/test/basics/aligned_writeE_basic.c
+++ b/test/basics/aligned_writeE_basic.c
@@ -55,6 +55,8 @@ int main(int argc,
 
     testWriteEOnFull();
     testWriteEOnEmpty();
+
+    return 0;
 }
 
 /* vim:set expandtab */

--- a/test/basics/aligned_writeE_wakes.c
+++ b/test/basics/aligned_writeE_wakes.c
@@ -66,6 +66,8 @@ int main(int argc,
     iprintf("  %i threads total\n", qthread_num_workers());
 
     testWriteEWakes();
+
+    return 0;
 }
 
 /* vim:set expandtab */

--- a/test/basics/aligned_writeFF_basic.c
+++ b/test/basics/aligned_writeFF_basic.c
@@ -74,6 +74,8 @@ int main(int argc,
 
     testBasicWriteFF();
     testConcurrentWriteFF();
+
+    return 0;
 }
 
 /* vim:set expandtab */

--- a/test/basics/aligned_writeFF_waits.c
+++ b/test/basics/aligned_writeFF_waits.c
@@ -68,6 +68,8 @@ int main(int argc,
     iprintf("  %i threads total\n", qthread_num_workers());
 
     testWriteFFWaits();
+
+    return 0;
 }
 
 /* vim:set expandtab */


### PR DESCRIPTION
Whoops, not all compilers have an implicit "return 0" if the end of main is
reached. These tests were failing with some versions of pgi because of this.