### PR TITLE
Quiet Clang's "abs value of unsigned type has no effect" warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -511,6 +511,19 @@ AS_IF([test "x$enable_picky" = xyes],
            ;;
          esac])
 
+AS_IF([test "x$enable_picky" = x],
+      [case "$qthread_cv_c_compiler_type" in dnl (
+         Clang)
+           CFLAGS="-Wno-unknown-warning-option -Wno-absolute-value $CFLAGS"
+           ;;
+       esac
+       case "$qthread_cv_cxx_compiler_type" in dnl (
+         Clang)
+           CXXFLAGS="-Wno-unknown-warning-option -Wno-absolute-value $CXXFLAGS"
+           ;;
+         esac])
+
+
 QTHREAD_CHECK_ASSEMBLY([have_assembly=1], [have_assembly=0])
 case "$qthread_cv_asm_arch" in
     POWERPC32|SPARCV9_32)


### PR DESCRIPTION
[clang 3.5] (http://llvm.org/releases/3.5.0/tools/clang/docs/ReleaseNotes.html) added a warning to indicate that taking the absolute value of an unsigned type has no effect. Qthreads gets this warning with `TEAM_SIGNAL_SENDERID(team_id)`, which is a simple `labs(team_id)` wrapper that's only used once on an aligned_t variable.

I considered just removing the `labs`, but decided against it because `TEAM_SIGNAL_SENDERID` could be used at some point in the future on a signed type. `labs` was originally added with 5d2bca4, but even then it looks like it wasn't technically needed so I figure there could have been some future motivation for adding it.

Unlike [gcc](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html), clang's `-Wno-<warning>` flags will cause another warning if the warning being disable doesn't exist, so I also added `-Wno-unknown-warning-option`
