### PR TITLE
Fix a few issues uncovered during full Chapel testing of qthreads 1.12

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,8 @@ EXTRA_DIST += \
 			 barrier/array.c \
 			 barrier/log.c \
 			 barrier/sinc.c \
+			 alloc/base.c \
+			 alloc/chapel.c \
 			 affinity/common.c \
 			 affinity/hwloc.c \
 			 affinity/binders.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,7 +35,7 @@ libqthread_la_SOURCES = \
 	touch.c \
 	teams.c
 
-EXTRA_DIST = alloc/
+EXTRA_DIST = 
 
 if COMPILE_LF_HASH
 libqthread_la_SOURCES += lf_hashmap.c

--- a/src/alloc/chapel.c
+++ b/src/alloc/chapel.c
@@ -13,6 +13,8 @@ static QINLINE int getpagesize()
 }
 #endif
 
+#include <qthread/qthread-int.h> /* for uint_fast16_t */
+
 #include "chpl-mem-impl.h"
 
 void *qt_malloc(size_t size){

--- a/src/qthread.c
+++ b/src/qthread.c
@@ -1881,7 +1881,7 @@ unsigned API_FUNC qthread_size_tasklocal(void)
     return f->rdata->tasklocal_size ? f->rdata->tasklocal_size : qlib->qthread_tasklocal_size;
 } /*}}}*/
 
-void* API_FUNC qthread_tos(void)
+API_FUNC void* qthread_tos(void)
 {
     const qthread_t *f = qthread_internal_self();
 
@@ -1889,7 +1889,7 @@ void* API_FUNC qthread_tos(void)
 }
 
 
-void* API_FUNC qthread_bos(void)
+API_FUNC void* qthread_bos(void)
 {
     const qthread_t *f = qthread_internal_self();
 


### PR DESCRIPTION
 - Add individual allocators to EXTRA_DIST to avoid .deps in release tarball
 - Bring in qthread-int.h for uint_fast16_t in chapel.c
 - Quiet qthread_tos()/qthread_bos() visibility warning. See #50 for more info

Individual commits have more detail
