### PR TITLE
Fix ignored attributes warning

### DIFF
--- a/include/qthread/qthread.hpp
+++ b/include/qthread/qthread.hpp
@@ -14,7 +14,11 @@
 template <bool> class OnlyTrue;
 template <> class OnlyTrue<true>
 {};
+#if __cplusplus >= 201103
+#define QTHREAD_STATIC_ASSERT(X) static_assert((X), #X)
+#else
 #define QTHREAD_STATIC_ASSERT(X) (void)sizeof(OnlyTrue<(bool)(X)>)
+#endif
 #define QTHREAD_CHECKSIZE(X)     QTHREAD_STATIC_ASSERT(sizeof(X) == sizeof(aligned_t))
 
 #define QTHREAD_CHECKINTEGER(X)  QTHREAD_STATIC_ASSERT(std::numeric_limits<X>::is_integer)


### PR DESCRIPTION
This fixes a warning encountered in Chapel, which is turned into an error when \-Werror is used.

Qthreads has a clever implementation of `static_assert()` called `QTHREAD_STATIC_ASSERT()` that works even with older versions of the C\+\+ standard.  Unfortunately, the stricter checking performed by gcc 7.1 causes `QTHREAD_STATIC_ASSERT()` to provoke a warning that attributes are being ignored in a template argument.

The fix proposed here is to use the standard `static_assert()` when it is available (i.e. when using C\+\+11 or later).

@ronawho suggested that I submit this as a Qthreads PR since it has been implemented in Chapel's copy of Qthreads.