### PR TITLE
Fix a bug in pool limiting code

### DIFF
--- a/src/mpool.c
+++ b/src/mpool.c
@@ -180,6 +180,9 @@ qt_mpool INTERNAL qt_mpool_create_aligned(size_t item_size,
       /* adjust item_size to be a multiple of pagesize */
       item_size += pagesize - (item_size % pagesize);
       max_num_items = max_alloc_size / item_size; /* floor */
+      if (max_num_items < 2) {
+          max_num_items = 2;
+      }
       alloc_size = item_size * max_num_items;
     }
 


### PR DESCRIPTION
Ensure that we can store at least 2 items per pool (missed in
https://github.com/chapel-lang/chapel/commit/93869777321 / https://github.com/Qthreads/qthreads/commit/5dc11401)

Partial cherry-pick of https://github.com/chapel-lang/chapel/commit/de54d106d1