### PR TITLE
Remove deprecated register keyword

### DIFF
--- a/include/qt_atomics.h
+++ b/include/qt_atomics.h
@@ -433,7 +433,7 @@ static QINLINE aligned_t qthread_internal_incr_mod_(aligned_t             *opera
     aligned_t retval;
 
 #if QTHREAD_ATOMIC_CAS && (QTHREAD_SIZEOF_ALIGNED_T == 4)
-    register uint32_t oldval, newval;
+    uint32_t oldval, newval;
 
     newval = *operand;
     do {
@@ -444,7 +444,7 @@ static QINLINE aligned_t qthread_internal_incr_mod_(aligned_t             *opera
         newval = __sync_val_compare_and_swap((uint32_t *)operand, oldval, newval);
     } while (oldval != newval);
 #elif QTHREAD_ATOMIC_CAS && (QTHREAD_SIZEOF_ALIGNED_T == 8)
-    register uint64_t oldval, newval;
+    uint64_t oldval, newval;
 
     newval = *operand;
     do {
@@ -458,8 +458,8 @@ static QINLINE aligned_t qthread_internal_incr_mod_(aligned_t             *opera
 # if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC32) || \
     ((QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC64) && (QTHREAD_SIZEOF_ALIGNED_T == 4))
 
-    register unsigned int incrd = incrd;        /* these don't need to be initialized */
-    register unsigned int compd = compd;        /* they're just tmp variables */
+    unsigned int incrd = incrd;        /* these don't need to be initialized */
+    unsigned int compd = compd;        /* they're just tmp variables */
 
     /* the minus in bne- means "this bne is unlikely to be taken" */
     asm volatile ("A_%=:\n\t"             /* local label */
@@ -481,8 +481,8 @@ static QINLINE aligned_t qthread_internal_incr_mod_(aligned_t             *opera
                   : "cc", "memory");
 
 # elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC64)
-    register uint64_t incrd = incrd;
-    register uint64_t compd = compd;
+    uint64_t incrd = incrd;
+    uint64_t compd = compd;
 
     asm volatile ("A_%=:\n\t"             /* local label */
                   "ldarx  %0,0,%3\n\t"    /* load operand */
@@ -501,7 +501,7 @@ static QINLINE aligned_t qthread_internal_incr_mod_(aligned_t             *opera
 # elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_32) || \
     ((QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_64) && (QTHREAD_SIZEOF_ALIGNED_T == 4))
 
-    register uint32_t oldval, newval;
+    uint32_t oldval, newval;
 
     /* newval = *operand; */
     do {
@@ -529,7 +529,7 @@ static QINLINE aligned_t qthread_internal_incr_mod_(aligned_t             *opera
     } while (oldval != newval);
 
 # elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_64)
-    register aligned_t oldval, newval;
+    aligned_t oldval, newval;
 
     /* newval = *operand; */
     do {
@@ -618,7 +618,7 @@ static QINLINE aligned_t qthread_internal_incr_mod_(aligned_t             *opera
             uint32_t h;
         } s;
     } oldval, newval;
-    register char test;
+    char test;
 
     do {
 #  ifdef __PIC__

--- a/include/qt_int_log.h
+++ b/include/qt_int_log.h
@@ -14,8 +14,8 @@ static const char LogTable256[256] = {
 static inline uint32_t QT_INT_LOG(uint32_t v)
 {
     uint32_t          r;
-    register uint32_t t;
-    register uint32_t tt;
+    uint32_t t;
+    uint32_t tt;
 
     if ((tt = (v >> 16))) {
         r = (t = tt >> 8) ? 24 + LogTable256[t] : 16 + LogTable256[tt];

--- a/include/qthread/loop_iter.hpp
+++ b/include/qthread/loop_iter.hpp
@@ -417,7 +417,7 @@ template <class IterT>
 aligned_t run_qtd (void *arg)
 {
     IterT *iter        = (IterT *)arg;
-    register int count = iter->Count();
+    int count = iter->Count();
 
     for (int i = 0; i < count; i++) {
         iter->Run();

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -608,8 +608,8 @@ static QINLINE float qthread_fincr(float *operand,
         float    f;
         uint32_t i;
     } retval;
-    register float    incremented_value;
-    register uint32_t scratch_int;
+    float    incremented_value;
+    uint32_t scratch_int;
     uint32_t          conversion_memory = conversion_memory;
     __asm__ __volatile__ ("A_%=:\n\t"
                           "lwarx  %0,0,%4\n\t"
@@ -702,7 +702,7 @@ static QINLINE float qthread_fincr(float *operand,
         float    f;
         uint32_t i;
     } oldval, newval, retval;
-    register uint32_t scratch_int = scratch_int;
+    uint32_t scratch_int = scratch_int;
 
     retval.f = *(volatile float *)operand;
     do {
@@ -760,8 +760,8 @@ static QINLINE double qthread_dincr(double *operand,
 # error Qthreads requires either mutex increments, inline assembly, or compiler CAS builtins
 #else  // if defined(QTHREAD_MUTEX_INCREMENT) || (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC32)
 # if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC64)
-    register uint64_t scratch_int;
-    register double   incremented_value;
+    uint64_t scratch_int;
+    double   incremented_value;
     union {
         uint64_t i;
         double   d;
@@ -801,8 +801,8 @@ static QINLINE double qthread_dincr(double *operand,
     do {
         /* this allows the compiler to be as flexible as possible with register
          * assignments */
-        register uint64_t tmp1;
-        register uint64_t tmp2;
+        uint64_t tmp1;
+        uint64_t tmp2;
 
         oldval.d  = newval.d;
         newval.d += incr;
@@ -913,7 +913,7 @@ static QINLINE double qthread_dincr(double *operand,
             uint32_t h;
         } s;
     } oldval, newval;
-    register char test;
+    char test;
 
     do {
 #  ifdef __PIC__
@@ -970,7 +970,7 @@ static QINLINE double qthread_dincr(double *operand,
             uint32_t t, b;
         } s;
     } oldval, newval, retval;
-    register uint32_t tmp = tmp;
+    uint32_t tmp = tmp;
 
     retval.f = *(volatile double *)operand;
     do {
@@ -1032,7 +1032,7 @@ static QINLINE uint32_t qthread_incr32(uint32_t *operand,
 # if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC32) || \
     (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC64)
     uint32_t              retval;
-    register unsigned int incrd = incrd;        /* no initializing */
+    unsigned int incrd = incrd;        /* no initializing */
     __asm__ __volatile__ ("A_%=:\tlwarx  %0,0,%2\n\t"
                           "add    %1,%0,%3\n\t"
                           "stwcx. %1,0,%2\n\t"
@@ -1046,7 +1046,7 @@ static QINLINE uint32_t qthread_incr32(uint32_t *operand,
 
 # elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_32) || \
     (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_64)
-    register uint32_t oldval, newval;
+    uint32_t oldval, newval;
 
     /* newval = *operand; */
     do {
@@ -1138,7 +1138,7 @@ static QINLINE uint64_t qthread_incr64(uint64_t *operand,
 #else  // if defined(QTHREAD_MUTEX_INCREMENT) || (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC32) || (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_32)
 # if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC64)
     uint64_t          retval;
-    register uint64_t incrd = incrd;    /* no initializing */
+    uint64_t incrd = incrd;    /* no initializing */
 
     asm volatile ("A_%=:\tldarx  %0,0,%2\n\t"
                   "add    %1,%0,%3\n\t"
@@ -1157,8 +1157,8 @@ static QINLINE uint64_t qthread_incr64(uint64_t *operand,
     do {
         /* this allows the compiler to be as flexible as possible with register
          * assignments */
-        register uint64_t tmp1 = tmp1;
-        register uint64_t tmp2 = tmp2;
+        uint64_t tmp1 = tmp1;
+        uint64_t tmp2 = tmp2;
 
         oldval  = newval;
         newval += incr;
@@ -1178,7 +1178,7 @@ static QINLINE uint64_t qthread_incr64(uint64_t *operand,
     return oldval;
 
 # elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_64)
-    register uint64_t oldval, newval;
+    uint64_t oldval, newval;
 
 #  ifdef QTHREAD_ATOMIC_CAS
     newval = *operand;
@@ -1245,7 +1245,7 @@ static QINLINE uint64_t qthread_incr64(uint64_t *operand,
             uint32_t h;
         } s;
     } oldval, newval;
-    register char test;
+    char test;
 
     do {
 #  ifndef QTHREAD_PIC_PREFIX
@@ -1355,7 +1355,7 @@ static QINLINE uint32_t qthread_cas32(uint32_t *operand,
 # else
 #  if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC32) || \
     (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC64)
-    register uint32_t result;
+    uint32_t result;
     __asm__ __volatile__ ("A_%=:\n\t"
                           "lwarx  %0,0,%3\n\t"
                           "cmpw   %0,%1\n\t"
@@ -1371,7 +1371,7 @@ static QINLINE uint32_t qthread_cas32(uint32_t *operand,
 
 #  elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_32) || \
     (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_64)
-    register uint32_t newv = newval;
+    uint32_t newv = newval;
     __asm__ __volatile__
     ("membar #StoreStore|#LoadStore|#StoreLoad|#LoadLoad\n\t"
      "cas [%1], %2, %0"
@@ -1381,7 +1381,7 @@ static QINLINE uint32_t qthread_cas32(uint32_t *operand,
     return newv;
 
 #  elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_IA64)
-    register uint32_t retval;
+    uint32_t retval;
     __asm__ __volatile__ ("mov ar.ccv=%0;;" : : "rO" (oldval));
     __asm__ __volatile__ ("cmpxchg4.acq %0=[%1],%2,ar.ccv"
                           : "=r" (retval)
@@ -1419,7 +1419,7 @@ static QINLINE uint64_t qthread_cas64(uint64_t *operand,
 
 # else
 #  if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC64)
-    register uint64_t result;
+    uint64_t result;
     __asm__ __volatile__ ("A_%=:\n\t"
                           "ldarx  %0,0,%3\n\t"
                           "cmpw   %0,%1\n\t"
@@ -1434,8 +1434,8 @@ static QINLINE uint64_t qthread_cas64(uint64_t *operand,
     return result;
 
 #  elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_32)
-    register uint64_t tmp1 = tmp1;
-    register uint64_t tmp2 = tmp2;
+    uint64_t tmp1 = tmp1;
+    uint64_t tmp2 = tmp2;
     uint64_t          newv = newval;
     __asm__ __volatile__
     ("ldx %0, %1\n\t"
@@ -1451,7 +1451,7 @@ static QINLINE uint64_t qthread_cas64(uint64_t *operand,
     return newv;
 
 #  elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_SPARCV9_64)
-    register uint64_t newv = newval;
+    uint64_t newv = newval;
     __asm__ __volatile__
     ("membar #StoreStore|#LoadStore|#StoreLoad|#LoadLoad\n\t"
      "casx [%1], %2, %0"
@@ -1461,7 +1461,7 @@ static QINLINE uint64_t qthread_cas64(uint64_t *operand,
     return newv;
 
 #  elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_IA64)
-    register uint32_t retval;
+    uint32_t retval;
     __asm__ __volatile__ ("mov ar.ccv=%0;;" : : "rO" (oldval));
     __asm__ __volatile__ ("cmpxchg8.acq %0=[%1],%2,ar.ccv"
                           : "=r" (retval)

--- a/src/ds/dictionary/hash.c
+++ b/src/ds/dictionary/hash.c
@@ -21,7 +21,7 @@ uint64_t API_FUNC qt_hash64(uint64_t key)
     };
 
 #if (SIZEOF_VOIDP == 8) /* i.e. a 64-bit machine */
-    register uint64_t a, b, c;
+    uint64_t a, b, c;
 
     a = b = 0x9e3779b97f4a7c13LL;   // the golden ratio
     c = 0xdeadbeefcafebabeULL + sizeof(uint64_t);
@@ -50,7 +50,7 @@ uint64_t API_FUNC qt_hash64(uint64_t key)
     return c;
 
 #else /* i.e. a 32-bit machine */
-    register uint32_t a, b, c;
+    uint32_t a, b, c;
 
     a = b = 0x9e3779b9;   // golden ratio
     c = 0xdeadbeef + sizeof(uint64_t);
@@ -115,7 +115,7 @@ aligned_t API_FUNC qt_hash_bytes(void     *key_ptr,
                                  size_t    bytes,
                                  aligned_t state)
 {
-    register aligned_t a, b, c;   /* internal state */
+    aligned_t a, b, c;   /* internal state */
     size_t             len = bytes;
     const uint8_t     *k   = key_ptr;
 

--- a/src/performance.c
+++ b/src/performance.c
@@ -33,7 +33,7 @@ void qtperf_free_perf_list(qtstategroup_t*,qtperf_perf_list_t*);
 static inline void spin_lock(volatile uint32_t* busy);
 
 static inline void spin_lock(volatile uint32_t* busy){
-  register bool stopped = 0;
+  bool stopped = 0;
   while(qthread_cas32(busy, 0, 1) != 0){
     stopped = 1;
   }

--- a/src/qloop.c
+++ b/src/qloop.c
@@ -1284,7 +1284,7 @@ PARALLEL_FUNC(min, dmin, MIN, double, double)
  * repeated operations on the same array will divide the array in the same
  * fashion every time.
  */
-#define SWAP(a, m, n) do { register double temp = a[m]; a[m] = a[n]; a[n] = temp; } while (0)
+#define SWAP(a, m, n) do { double temp = a[m]; a[m] = a[n]; a[n] = temp; } while (0)
 static int dcmp(const void *restrict a,
                 const void *restrict b)
 {

--- a/src/qutil.c
+++ b/src/qutil.c
@@ -547,7 +547,7 @@ void API_FUNC qutil_mergesort(double *array,
     }
 } /*}}}*/
 
-#define SWAP(t, a, m, n) do { register t temp = a[m]; a[m] = a[n]; a[n] = temp; } while (0)
+#define SWAP(t, a, m, n) do { t temp = a[m]; a[m] = a[n]; a[n] = temp; } while (0)
 #define MT_CHUNKSIZE (qthread_cacheline() / sizeof(double))
 
 struct qutil_qsort_args {

--- a/src/syncvar.c
+++ b/src/syncvar.c
@@ -170,7 +170,7 @@ loop_start:
         locked.u.w = addr->u.w; // I locked it, so I can read it
 #else                           /* if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_TILEPRO) */
         {
-            register syncvar_t tmp;
+            syncvar_t tmp;
 loop_start:
             tmp = *addr;
             do {


### PR DESCRIPTION
The `register` keyword is deprecated in C++, and some compilers are starting to issue warnings when they see it.  This can cause problems for projects that use `-Werror` because the build aborts upon seeing the warnings.

Chapel is one such project.  In the Chapel runtime, `qthread.h` is included from both C and C++ code, and the C++ code now aborts when compiling for a target such as IA32, for which `qthread.h` contains `register` declarations.

For consistency, this PR removes the `register` keyword everywhere, not just in `qthread.h`.  We'd appreciate it if this PR or something equivalent could be merged.

@gbtitus , @ronawho - FYI.