### PR TITLE
Use relative paths to include Qthreads headers in public headers

### DIFF
--- a/include/qthread/Makefile.am
+++ b/include/qthread/Makefile.am
@@ -3,7 +3,7 @@
 # Copyright (c)      2008  Sandia Corporation
 #
 
-include_HEADERS = qthread.h
+include_HEADERS = top/qthread.h
 pkginclude_HEADERS = \
 	allpairs.h \
 	barrier.h \

--- a/include/qthread/allpairs.h
+++ b/include/qthread/allpairs.h
@@ -1,8 +1,8 @@
 #ifndef QTHREAD_ALLPAIRS_H
 #define QTHREAD_ALLPAIRS_H
 
-#include <qthread/macros.h>
-#include <qthread/qarray.h>
+#include "macros.h"
+#include "qarray.h"
 
 Q_STARTCXX                             /* */
 typedef void (*dist_f)(const void *unit1, const void *unit2);

--- a/include/qthread/barrier.h
+++ b/include/qthread/barrier.h
@@ -1,8 +1,8 @@
 #ifndef QTHREAD_LOG_BARRIER_H
 #define QTHREAD_LOG_BARRIER_H
 
-#include <qthread/macros.h>
-#include <qthread/qthread.h>
+#include "macros.h"
+#include "qthread.h"
 
 Q_STARTCXX
 /************************************************************/

--- a/include/qthread/cacheline.h
+++ b/include/qthread/cacheline.h
@@ -1,7 +1,7 @@
 #ifndef QTHREAD_CACHELINE_H
 #define QTHREAD_CACHELINE_H
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX                             /* */
 int qthread_cacheline(void);

--- a/include/qthread/dictionary.h
+++ b/include/qthread/dictionary.h
@@ -3,7 +3,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX /* */
 

--- a/include/qthread/hash.h
+++ b/include/qthread/hash.h
@@ -1,9 +1,9 @@
 #ifndef QTHREAD_HASH_H
 #define QTHREAD_HASH_H
 
-#include <qthread/macros.h>
-#include <qthread/common.h>            /* important configuration options */
-#include <qthread/qthread.h>           /* for uint64_t, uint8_t, and aligned_t types */
+#include "macros.h"
+#include "common.h"            /* important configuration options */
+#include "qthread.h"           /* for uint64_t, uint8_t, and aligned_t types */
 
 Q_STARTCXX /* */
 

--- a/include/qthread/io.h
+++ b/include/qthread/io.h
@@ -1,7 +1,7 @@
 #ifndef QTHREAD_IO_H
 #define QTHREAD_IO_H
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX
 void qt_begin_blocking_action(void);

--- a/include/qthread/omp_defines.h
+++ b/include/qthread/omp_defines.h
@@ -1,7 +1,7 @@
 #ifndef OMP_DEFINES_H
 #define OMP_DEFINES_H
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 // this file prototypes the OMP calls supplied by the Qthreads implementation
 //   the user is expected to use omp.h from amother implementation, but the

--- a/include/qthread/qarray.h
+++ b/include/qthread/qarray.h
@@ -1,9 +1,9 @@
 #ifndef QTHREAD_QARRAY_H
 #define QTHREAD_QARRAY_H
 
-#include <qthread/qthread-int.h>
-#include <qthread/macros.h>
-#include <qthread/qloop.h>
+#include "qthread-int.h"
+#include "macros.h"
+#include "qloop.h"
 
 Q_STARTCXX                             /* */
 typedef enum {

--- a/include/qthread/qdqueue.h
+++ b/include/qthread/qdqueue.h
@@ -1,7 +1,7 @@
 #ifndef QTHREAD_QDQUEUE_H
 #define QTHREAD_QDQUEUE_H
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX                             /* */
 typedef struct qdqueue_s qdqueue_t;

--- a/include/qthread/qlfqueue.h
+++ b/include/qthread/qlfqueue.h
@@ -1,7 +1,7 @@
 #ifndef QTHREAD_QLFQUEUE_H
 #define QTHREAD_QLFQUEUE_H
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX /* */
 

--- a/include/qthread/qloop.h
+++ b/include/qthread/qloop.h
@@ -1,7 +1,7 @@
 #ifndef QTHREAD_QLOOP
 #define QTHREAD_QLOOP
 
-#include <qthread/qthread.h>
+#include "qthread.h"
 
 Q_STARTCXX                             /* */
 /* for convenient arguments to qt_loop */

--- a/include/qthread/qloop.hpp
+++ b/include/qthread/qloop.hpp
@@ -1,7 +1,7 @@
 #ifndef QLOOP_HPP
 #define QLOOP_HPP
 
-#include <qthread/qloop.h>
+#include "qloop.h"
 
 template <typename T>
 void qloop_cpp_wrapper(size_t startat,

--- a/include/qthread/qpool.h
+++ b/include/qthread/qpool.h
@@ -3,7 +3,7 @@
 
 #include <stddef.h>                    /* for size_t (according to C89) */
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX /* */
 

--- a/include/qthread/qswsrqueue.h
+++ b/include/qthread/qswsrqueue.h
@@ -1,7 +1,7 @@
 #ifndef QTHREAD_QSWSRQUEUE_H
 #define QTHREAD_QSWSRQUEUE_H
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX /* */
 

--- a/include/qthread/qt_syscalls.h
+++ b/include/qthread/qt_syscalls.h
@@ -7,7 +7,7 @@
 #include <sys/resource.h> /* for struct rusage */
 #include <poll.h>         /* for struct pollfd and nfds_t */
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX /* */
 

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -4,8 +4,8 @@
 #include <errno.h>                     /* for ENOMEM */
 
 #include <limits.h>                    /* for UINT_MAX (C89) */
-#include <qthread/qthread-int.h>       /* for uint32_t and uint64_t */
-#include <qthread/common.h>            /* important configuration options */
+#include "qthread-int.h"               /* for uint32_t and uint64_t */
+#include "common.h"                    /* important configuration options */
 
 #include <string.h>                    /* for memcpy() */
 
@@ -53,7 +53,7 @@
 
 #define QTHREAD_VERSION 1010001
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 #ifdef QTHREAD_ALIGNEDDATA_ALLOWED
 # define Q_ALIGNED(x) __attribute__((aligned(x)))
@@ -1639,7 +1639,7 @@ Q_ENDCXX /* */
 
 #else  /* ifdef __cplusplus */
 extern "C++" {
-# include <qthread/qthread.hpp>
+# include "qthread.hpp"
 }
 #endif  /* __cplusplus */
 

--- a/include/qthread/qthread.hpp
+++ b/include/qthread/qthread.hpp
@@ -8,8 +8,8 @@
 
 #include <limits>
 
-#include <qthread/qthread.h>
-#include <qthread/syncvar.hpp>
+#include "qthread.h"
+#include "syncvar.hpp"
 
 template <bool> class OnlyTrue;
 template <> class OnlyTrue<true>

--- a/include/qthread/qtimer.h
+++ b/include/qthread/qtimer.h
@@ -1,7 +1,7 @@
 #ifndef QTHREAD_TIMER
 #define QTHREAD_TIMER
 
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX /* */
 

--- a/include/qthread/qutil.h
+++ b/include/qthread/qutil.h
@@ -1,7 +1,7 @@
 #ifndef QTHREAD_QUTIL_H
 #define QTHREAD_QUTIL_H
 
-#include <qthread/qthread.h>
+#include "qthread.h"
 
 Q_STARTCXX /* */
 

--- a/include/qthread/sinc.h
+++ b/include/qthread/sinc.h
@@ -1,6 +1,6 @@
 #ifndef QT_SINC_H
 #define QT_SINC_H
-#include <qthread/macros.h>
+#include "macros.h"
 
 Q_STARTCXX /* */
 

--- a/include/qthread/spr.h
+++ b/include/qthread/spr.h
@@ -1,7 +1,7 @@
 #ifndef SPR_H
 #define SPR_H
 
-#include <qthread/qthread.h>
+#include "qthread.h"
 
 Q_STARTCXX /* */
 

--- a/include/qthread/syncvar.hpp
+++ b/include/qthread/syncvar.hpp
@@ -2,7 +2,7 @@
 #define QTHREAD_SYNCVAR_HPP
 
 #include <assert.h>
-#include <qthread/qthread.h>
+#include "qthread.h"
 
 class syncvar;
 

--- a/include/qthread/top/qthread.h
+++ b/include/qthread/top/qthread.h
@@ -1,0 +1,2 @@
+
+#include "qthread/qthread.h"

--- a/include/qthread/wavefront.h
+++ b/include/qthread/wavefront.h
@@ -1,7 +1,7 @@
 #ifndef QTHREAD_WAVEFRONT_H
 #define QTHREAD_WAVEFRONT_H
 
-#include <qthread/qarray.h>
+#include "qarray.h"
 
 Q_STARTCXX                             /* */
 typedef void (*wave_comp_f)(const void *restrict left,


### PR DESCRIPTION
This PR addresses #70 

Public headers (e.g., `qthread.h`) writes `#include <qthread/xxx.h>` to include other Qthreads headers.  The compiler only looks up global include paths, so a compiler cannot find headers if the Qthreads' include path (`QTHREAD_INSTALL_DIR/include`) is not added to its global include paths.  This patch fixes it by using relative paths (`#include "xxx.h"`).

Note that this change does not break the existing program that includes Qthreads by `#include<qthread.h>` or `#include <qthread/qthread.h>`.