### PR TITLE
Add missing header

### DIFF
--- a/src/compat_atomics.c
+++ b/src/compat_atomics.c
@@ -7,6 +7,7 @@
 #include "qt_asserts.h"
 #include "qthread_innards.h"
 #include "qt_profiling.h"
+#include "qt_initialized.h"
 
 extern unsigned int QTHREAD_LOCKING_STRIPES;
 #define QTHREAD_CHOOSE_STRIPE(addr) (((size_t)addr >> 4) & (QTHREAD_LOCKING_STRIPES - 1))

--- a/src/qthread.c
+++ b/src/qthread.c
@@ -829,6 +829,11 @@ int API_FUNC qthread_initialize(void)
     qt_internal_alignment_init();
     qt_hash_initialize_subsystem();
 
+#ifndef QTHREAD_NO_ASSERTS
+    qthread_library_initialized = 1;
+    MACHINE_FENCE;
+#endif
+
     qt_topology_init(&nshepherds,
                      &nworkerspershep,
                      &hw_par);
@@ -936,10 +941,7 @@ int API_FUNC qthread_initialize(void)
     }
     qaffinity = qt_internal_get_env_bool("AFFINITY", 1);
     qthread_debug(AFFINITY_DETAILS, "qaffinity = %i\n", qaffinity);
-#ifndef QTHREAD_NO_ASSERTS
-    qthread_library_initialized = 1;
-    MACHINE_FENCE;
-#endif
+
     {
         int ret = qt_affinity_gendists(qlib->shepherds, nshepherds);
         if (ret != QTHREAD_SUCCESS) {


### PR DESCRIPTION
Fixes failing compilation when QThreads configured with certain options.