### PR TITLE
Mac allow system ucontext

### DIFF
--- a/config/qthread_check_swapcontext.m4
+++ b/config/qthread_check_swapcontext.m4
@@ -63,13 +63,7 @@ AS_IF([test "x$ac_cv_func_getcontext" = "xyes"], [
 				   [the uc_stack structure in ucontext_t has an ss_flags structure that needs to be initialized])])
 AC_CACHE_CHECK([whether swapcontext works properly],
   [qthread_cv_swapcontext_works],
-  [
-  case "$host" in
-#  *-darwin*)
-#  qthread_cv_swapcontext_works=no
-#  ;;
-  *)
-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+  [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <ucontext.h>
 #include <stdlib.h>
 ucontext_t child, parent;
@@ -97,9 +91,7 @@ int main()
 	       [AS_IF([test "x$enable_fastcontext" = xyes],
 		          [qthread_cv_swapcontext_works=no],
 				  [qthread_cv_swapcontext_works=yes])],
-	       [qthread_cv_swapcontext_works=yes])])
-	;;
-	esac])
+	       [qthread_cv_swapcontext_works=yes])])])
 AS_IF([test "$qthread_cv_swapcontext_works" = yes],
 	[AC_DEFINE([HAVE_NATIVE_MAKECONTEXT], [1], [The system provides functional native make/swap/get-context functions])
 	 QTHREAD_CHECK_MAKECONTEXT_SPLIT_ARGS(

--- a/config/qthread_check_swapcontext.m4
+++ b/config/qthread_check_swapcontext.m4
@@ -65,9 +65,9 @@ AC_CACHE_CHECK([whether swapcontext works properly],
   [qthread_cv_swapcontext_works],
   [
   case "$host" in
-  *-darwin*)
-  qthread_cv_swapcontext_works=no
-  ;;
+#  *-darwin*)
+#  qthread_cv_swapcontext_works=no
+#  ;;
   *)
   AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <ucontext.h>

--- a/src/fastcontext/asm.S
+++ b/src/fastcontext/asm.S
@@ -43,7 +43,7 @@
 #  define SET _qt_setmctxt
 #  define GET _qt_getmctxt
 # else
-#  error What kind of a Mac is this? If M1, use --disable-fastcontext --with-default-stack-size=65536 in configure.
+#  error What kind of a Mac is this? If M1, use CFLAGS=-D_XOPEN_SOURCE and --disable-fastcontext --with-default-stack-size=65536 in configure.
 # endif
 #elif defined(__linux__)
 # if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_ARM)

--- a/src/fastcontext/asm.S
+++ b/src/fastcontext/asm.S
@@ -43,7 +43,7 @@
 #  define SET _qt_setmctxt
 #  define GET _qt_getmctxt
 # else
-#  error What kind of a Mac is this?
+#  error What kind of a Mac is this? If M1, use --disable-fastcontext --with-default-stack-size=65536 in configure.
 # endif
 #elif defined(__linux__)
 # if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_ARM)


### PR DESCRIPTION
Removes case block in m4 file. This allows to use ucontext on Macs and removes the requirement to use fast context on all Macs. Using fast context is current unsupported on M1 Macs. This resolves the compilation error.