### PR TITLE
Change calls to QTHREAD_TRYLOCK_{INIT,DESTROY} to pass-by-ref

### DIFF
--- a/src/threadqueues/distrib_threadqueues.c
+++ b/src/threadqueues/distrib_threadqueues.c
@@ -116,7 +116,7 @@ qt_threadqueue_t INTERNAL *qt_threadqueue_new(void){
       q->head              = NULL;
       q->tail              = NULL;
       q->qlength           = 0;
-      QTHREAD_TRYLOCK_INIT(q->qlock);
+      QTHREAD_TRYLOCK_INIT_PTR(&q->qlock);
     }
   }
   for(size_t i=0; i<qlib->nshepherds * qlib->nworkerspershep; i++){
@@ -152,7 +152,7 @@ void INTERNAL qt_threadqueue_free(qt_threadqueue_t *qe){
       QTHREAD_TRYLOCK_UNLOCK(&q->qlock);
     }
     assert(q->head == q->tail);
-    QTHREAD_TRYLOCK_DESTROY(q->qlock);
+    QTHREAD_TRYLOCK_DESTROY_PTR(&q->qlock);
   }
   QTHREAD_COND_DESTROY(qe->cond);
   free_threadqueue(qe);

--- a/src/threadqueues/sherwood_threadqueues.c
+++ b/src/threadqueues/sherwood_threadqueues.c
@@ -245,7 +245,7 @@ qt_threadqueue_t INTERNAL *qt_threadqueue_new(void)
         q->tail              = NULL;
         q->qlength           = 0;
         q->qlength_stealable = 0;
-        QTHREAD_TRYLOCK_INIT(q->qlock);
+        QTHREAD_TRYLOCK_INIT_PTR(&q->qlock);
     }
 
     return q;
@@ -287,7 +287,7 @@ void INTERNAL qt_threadqueue_free(qt_threadqueue_t *q)
         QTHREAD_TRYLOCK_UNLOCK(&q->qlock);
     }
     assert(q->head == q->tail);
-    QTHREAD_TRYLOCK_DESTROY(q->qlock);
+    QTHREAD_TRYLOCK_DESTROY_PTR(&q->qlock);
     FREE_THREADQUEUE(q);
 } /*}}}*/
 


### PR DESCRIPTION
QTHREAD_TRYLOCK_INIT and QTHREAD_TRYLOCK_DESTROY initialized and destroyed local stack variables. This seems like unwanted behavior. Occasionally and interestingly on x86, uninitialized locks happened to be zero-initialized which resulted in working code. 