### PR TITLE
Fix memory consistency issues on PowerPC and ARM

### DIFF
--- a/include/qt_atomics.h
+++ b/include/qt_atomics.h
@@ -5,6 +5,7 @@
 
 #include <qthread/common.h>
 #include <qthread/qthread.h>
+#include <stdatomic.h>
 
 #ifdef QTHREAD_NEEDS_IA64INTRIN
 # ifdef HAVE_IA64INTRIN_H
@@ -26,8 +27,8 @@
 #elif (QTHREAD_ASSEMBLY_ARCH == QTHREAD_IA32) || \
     (QTHREAD_ASSEMBLY_ARCH == QTHREAD_AMD64)
 # define SPINLOCK_BODY() do { COMPILER_FENCE; __asm__ __volatile__ ("pause" ::: "memory"); } while (0)
-#else // ifdef QTHREAD_OVERSUBSCRIPTION
-# define SPINLOCK_BODY() do { COMPILER_FENCE; } while (0)
+#else 
+# define SPINLOCK_BODY() do { COMPILER_FENCE; atomic_thread_fence(memory_order_acquire); /*asm volatile("sync");*/ } while (0)
 #endif // ifdef QTHREAD_OVERSUBSCRIPTION
 
 #if defined(__tile__)
@@ -56,7 +57,9 @@ void qt_spin_exclusive_unlock(qt_spin_exclusive_t *);
 # define QTHREAD_FASTLOCK_LOCK(x)     { aligned_t val = qthread_incr(&(x)->enter, 1); \
                                         while (val != (x)->exit) SPINLOCK_BODY(); /* spin waiting for my turn */ }
 # define QTHREAD_FASTLOCK_UNLOCK(x)   do { COMPILER_FENCE; \
-                                           (x)->exit++; /* allow next guy's turn */ } while (0)
+                                           (x)->exit++; /* allow next guy's turn */ \
+                                           atomic_thread_fence(memory_order_release); \
+                                        } while (0)
 # define QTHREAD_FASTLOCK_DESTROY(x)
 # define QTHREAD_FASTLOCK_DESTROY_PTR(x)
 # define QTHREAD_FASTLOCK_TYPE        qt_spin_exclusive_t
@@ -132,9 +135,10 @@ typedef union qt_spin_trylock_s {
 # define QTHREAD_TRYLOCK_INIT_PTR(x) { (x)->u = 0; }
 # define QTHREAD_TRYLOCK_LOCK(x)     { uint32_t val = qthread_incr(&(x)->s.users, 1); \
                                        while (val != (x)->s.ticket) SPINLOCK_BODY(); /* spin waiting for my turn */ }
-# define QTHREAD_TRYLOCK_UNLOCK(x)   do { COMPILER_FENCE;                                               \
+# define QTHREAD_TRYLOCK_UNLOCK(x)   do { COMPILER_FENCE; \
                                           qthread_incr(&(x)->s.ticket, 1); /* allow next guy's turn */ \
-} while (0)
+                                          atomic_thread_fence(memory_order_release); \
+                                        } while (0)
 # define QTHREAD_TRYLOCK_DESTROY(x)
 # define QTHREAD_TRYLOCK_DESTROY_PTR(x)
 

--- a/include/qt_atomics.h
+++ b/include/qt_atomics.h
@@ -5,7 +5,19 @@
 
 #include <qthread/common.h>
 #include <qthread/qthread.h>
+
+#ifndef __STDC_NO_ATOMICS__
+#define USE_C11_MEMORY_FENCE
 #include <stdatomic.h>
+#endif
+
+#ifdef USE_C11_MEMORY_FENCE
+#define THREAD_FENCE_MEM_ACQUIRE atomic_thread_fence(memory_order_acquire)
+#define THREAD_FENCE_MEM_RELEASE atomic_thread_fence(memory_order_release)
+#else
+#define THREAD_FENCE_MEM_ACQUIRE MACHINE_FENCE
+#define THREAD_FENCE_MEM_RELEASE MACHINE_FENCE
+#endif
 
 #ifdef QTHREAD_NEEDS_IA64INTRIN
 # ifdef HAVE_IA64INTRIN_H
@@ -56,10 +68,10 @@ void qt_spin_exclusive_unlock(qt_spin_exclusive_t *);
 # define QTHREAD_FASTLOCK_INIT_PTR(x) { (x)->enter = 0; (x)->exit = 0; }
 # define QTHREAD_FASTLOCK_LOCK(x)     { aligned_t val = qthread_incr(&(x)->enter, 1); \
                                         while (val != (x)->exit) SPINLOCK_BODY(); \
-                                          atomic_thread_fence(memory_order_acquire); /* spin waiting for my turn */ }
+                                          THREAD_FENCE_MEM_ACQUIRE; /* spin waiting for my turn */ }
 # define QTHREAD_FASTLOCK_UNLOCK(x)   do { COMPILER_FENCE; \
                                            (x)->exit++; /* allow next guy's turn */ \
-                                           atomic_thread_fence(memory_order_release); \
+                                           THREAD_FENCE_MEM_RELEASE; \
                                         } while (0)
 # define QTHREAD_FASTLOCK_DESTROY(x)
 # define QTHREAD_FASTLOCK_DESTROY_PTR(x)
@@ -136,10 +148,10 @@ typedef union qt_spin_trylock_s {
 # define QTHREAD_TRYLOCK_INIT_PTR(x) { (x)->u = 0; }
 # define QTHREAD_TRYLOCK_LOCK(x)     { uint32_t val = qthread_incr(&(x)->s.users, 1); \
                                        while (val != (x)->s.ticket) SPINLOCK_BODY(); \
-                                          atomic_thread_fence(memory_order_acquire); /* spin waiting for my turn */ }
+                                          THREAD_FENCE_MEM_ACQUIRE; /* spin waiting for my turn */ }
 # define QTHREAD_TRYLOCK_UNLOCK(x)   do { COMPILER_FENCE; \
                                           qthread_incr(&(x)->s.ticket, 1); /* allow next guy's turn */ \
-                                          atomic_thread_fence(memory_order_release); \
+                                          THREAD_FENCE_MEM_RELEASE; \
                                         } while (0)
 # define QTHREAD_TRYLOCK_DESTROY(x)
 # define QTHREAD_TRYLOCK_DESTROY_PTR(x)
@@ -155,9 +167,8 @@ static inline int QTHREAD_TRYLOCK_TRY(qt_spin_trylock_t *x)
     newcmp         = cmp;
     newcmp.s.users = newcmp.s.ticket + 1;
 
-
     if(qthread_cas(&(x->u), cmp.u, newcmp.u) == cmp.u) { 
-        atomic_thread_fence(memory_order_acquire); 
+        THREAD_FENCE_MEM_ACQUIRE; 
         return 1;
     }
     return 0;

--- a/include/qt_atomics.h
+++ b/include/qt_atomics.h
@@ -70,8 +70,8 @@ void qt_spin_exclusive_unlock(qt_spin_exclusive_t *);
                                         while (val != (x)->exit) SPINLOCK_BODY(); \
                                           THREAD_FENCE_MEM_ACQUIRE; /* spin waiting for my turn */ }
 # define QTHREAD_FASTLOCK_UNLOCK(x)   do { COMPILER_FENCE; \
+					   THREAD_FENCE_MEM_RELEASE; \
                                            (x)->exit++; /* allow next guy's turn */ \
-                                           THREAD_FENCE_MEM_RELEASE; \
                                         } while (0)
 # define QTHREAD_FASTLOCK_DESTROY(x)
 # define QTHREAD_FASTLOCK_DESTROY_PTR(x)
@@ -150,8 +150,8 @@ typedef union qt_spin_trylock_s {
                                        while (val != (x)->s.ticket) SPINLOCK_BODY(); \
                                           THREAD_FENCE_MEM_ACQUIRE; /* spin waiting for my turn */ }
 # define QTHREAD_TRYLOCK_UNLOCK(x)   do { COMPILER_FENCE; \
+					  THREAD_FENCE_MEM_RELEASE; \
                                           qthread_incr(&(x)->s.ticket, 1); /* allow next guy's turn */ \
-                                          THREAD_FENCE_MEM_RELEASE; \
                                         } while (0)
 # define QTHREAD_TRYLOCK_DESTROY(x)
 # define QTHREAD_TRYLOCK_DESTROY_PTR(x)

--- a/include/qt_atomics.h
+++ b/include/qt_atomics.h
@@ -6,7 +6,7 @@
 #include <qthread/common.h>
 #include <qthread/qthread.h>
 
-#ifndef __STDC_NO_ATOMICS__
+#if (__STDC_VERSION__ >= 201112L) && (!defined(__STDC_NO_ATOMICS__))
 #define USE_C11_MEMORY_FENCE
 #include <stdatomic.h>
 #endif

--- a/test/stress/Makefile.am
+++ b/test/stress/Makefile.am
@@ -13,7 +13,8 @@ TESTS = \
 		precond_fib \
 		task_spawn \
 		test_spawn_simple \
-		precond_spawn_simple
+		precond_spawn_simple \
+		lock_acq_rel
 
 if HAVE_LIBM
 TESTS += subteams_uts
@@ -64,6 +65,8 @@ test_spawn_simple_SOURCES = test_spawn_simple.c
 syncvar_stream_SOURCES = syncvar_stream.c
 
 feb_stream_SOURCES = feb_stream.c
+
+lock_acq_rel_SOURCES = lock_acq_rel.c
 
 if HAVE_LIBM
 subteams_uts_SOURCES = subteams_uts.c

--- a/test/stress/lock_acq_rel.c
+++ b/test/stress/lock_acq_rel.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdio.h>
+#include <qthread/qthread.h>
+#include <qthread/qloop.h>
+
+static int64_t count = 0;
+static aligned_t lock;
+
+static void task(size_t start, size_t stop, void  *args_) {
+  qthread_lock(&lock);
+  count++;
+  qthread_unlock(&lock);
+}
+
+int main(int argc, char *argv[]) {
+    uint64_t iters = 1000000l;
+    assert(qthread_initialize() == 0);
+    qt_loop(0, iters, task, NULL);
+    assert(iters == count);
+    return 0;
+}


### PR DESCRIPTION
Adds the atomic type specifier (C11) to members of structs used for thread synchronization. This implements sequential consistency (memory_order_seq_cst) for loads and stores to these members. This PR should fix issues on weakly-ordered systems (ARM, PowerPC) as described here:
- Sinc issues with multiple workers per shepherd on power and arm [#57]
