### PR TITLE
Detect Power9 during configure of asm inline support on Lassen

### DIFF
--- a/config/qthread_check_assembly.m4
+++ b/config/qthread_check_assembly.m4
@@ -208,7 +208,7 @@ AC_DEFUN([QTHREAD_CHECK_ASSEMBLY],[
       qthread_gcc_inline_assign='"or %0,[$]0,[$]0" : "=&r"(ret)'
     ;;
 
-    powerpc-*|powerpc64-*)
+    powerpc*|powerpc64*)
       AS_IF([test "$ac_cv_sizeof_long" = "4"],
             [qthread_cv_asm_arch="POWERPC32"],
             [qthread_cv_asm_arch="POWERPC64"])


### PR DESCRIPTION
Lassen at LLNL reports `host='powerpc64le-unknown-linux-gnu'` thus the m4 script does not detect the architecture correctly.