### PR TITLE
[WIP] Add support for recursive locks and try_lock 

### DIFF
--- a/include/qt_addrstat.h
+++ b/include/qt_addrstat.h
@@ -18,6 +18,8 @@ static QINLINE qthread_addrstat_t *qthread_addrstat_new(void)
         ret->FEQ   = NULL;
         ret->FFQ   = NULL;
         ret->FFWQ  = NULL;
+        ret->acq_owner_stat.state = -1;
+        ret->acq_owner_stat.recursive_access_counter = 0;
         QTHREAD_EMPTY_TIMER_INIT(ret);
     }
     return ret;

--- a/include/qt_addrstat.h
+++ b/include/qt_addrstat.h
@@ -18,7 +18,7 @@ static QINLINE qthread_addrstat_t *qthread_addrstat_new(void)
         ret->FEQ   = NULL;
         ret->FFQ   = NULL;
         ret->FFWQ  = NULL;
-        ret->acq_owner_stat.state = -1;
+        ret->acq_owner_stat.state = FEB_is_not_recursive_lock;
         ret->acq_owner_stat.recursive_access_counter = 0;
         QTHREAD_EMPTY_TIMER_INIT(ret);
     }

--- a/include/qt_blocking_structs.h
+++ b/include/qt_blocking_structs.h
@@ -9,7 +9,8 @@
 #include "qt_profiling.h"
 #include "qt_debug.h"
 
-#define FEB_is_recursive_lock  0
+#define FEB_is_recursive_lock (-1)
+#define FEB_is_not_recursive_lock (-2)
 
 typedef enum blocking_syscalls {
     ACCEPT,
@@ -49,8 +50,8 @@ typedef struct _qt_blocking_queue_node_s {
 } qt_blocking_queue_node_t;
 
 typedef struct qthread_acquire_owner_stat_s {
-    int_fast8_t          state;
-    int_fast8_t          recursive_access_counter;
+    int64_t         state;
+    int64_t         recursive_access_counter;
 } qthread_acquire_owner_stat_t;
 
 typedef struct qthread_addrstat_s {

--- a/include/qt_blocking_structs.h
+++ b/include/qt_blocking_structs.h
@@ -9,6 +9,8 @@
 #include "qt_profiling.h"
 #include "qt_debug.h"
 
+#define FEB_is_recursive_lock  0
+
 typedef enum blocking_syscalls {
     ACCEPT,
     CONNECT,
@@ -46,6 +48,11 @@ typedef struct _qt_blocking_queue_node_s {
     int                               err;
 } qt_blocking_queue_node_t;
 
+typedef struct qthread_acquire_owner_stat_s {
+    int_fast8_t          state;
+    int_fast8_t          recursive_access_counter;
+} qthread_acquire_owner_stat_t;
+
 typedef struct qthread_addrstat_s {
     QTHREAD_FASTLOCK_TYPE lock;
     qthread_addrres_t    *EFQ;
@@ -57,6 +64,8 @@ typedef struct qthread_addrstat_s {
 #endif
     uint_fast8_t          full;
     uint_fast8_t          valid;
+    qthread_acquire_owner_stat_t acq_owner_stat;
+
 } qthread_addrstat_t;
 
 #ifdef UNPOOLED

--- a/include/qt_feb.h
+++ b/include/qt_feb.h
@@ -17,6 +17,8 @@ typedef filter_code (*qt_feb_taskfilter_f)(qt_key_t            addr,
                                            qthread_t *restrict waiter,
                                            void *restrict      arg);
 
+int INTERNAL qthread_feb_adr_init(const aligned_t *dest, const bool is_from_recursive_lock);
+
 void INTERNAL qt_feb_subsystem_init(uint_fast8_t);
 
 int API_FUNC qthread_writeEF_nb(aligned_t *restrict const       dest,

--- a/include/qt_feb.h
+++ b/include/qt_feb.h
@@ -18,6 +18,7 @@ typedef filter_code (*qt_feb_taskfilter_f)(qt_key_t            addr,
                                            void *restrict      arg);
 
 int INTERNAL qthread_feb_adr_init(const aligned_t *dest, const bool is_from_recursive_lock);
+int INTERNAL qthread_feb_adr_remove(aligned_t *dest);
 
 void INTERNAL qt_feb_subsystem_init(uint_fast8_t);
 

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -555,6 +555,7 @@ int qthread_readXX(aligned_t       *dest,
 int qthread_lock(const aligned_t *a);
 int qthread_unlock(const aligned_t *a);
 int qthread_lock_init(const aligned_t *a, const bool is_recursive);
+int qthread_lock_destroy(aligned_t *a);
 
 const int qthread_trylock(const aligned_t *a);
 

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -8,6 +8,7 @@
 #include "common.h"                    /* important configuration options */
 
 #include <string.h>                    /* for memcpy() */
+#include <stdbool.h>                   /* for bool */
 
 #ifndef QTHREAD_NOALIGNCHECK
 # include <stdio.h>                    /* for fprintf() */
@@ -123,7 +124,6 @@ typedef struct _syncvar_s {
 
 typedef unsigned short qthread_shepherd_id_t;
 typedef unsigned short qthread_worker_id_t;
-
 
 /* for convenient arguments to qthread_fork */
 typedef aligned_t (*qthread_f)(void *arg);
@@ -434,6 +434,7 @@ int qthread_syncvar_status(syncvar_t *const v);
 int qthread_empty(const aligned_t *dest);
 int qthread_syncvar_empty(syncvar_t *restrict dest);
 int qthread_fill(const aligned_t *dest);
+int qthread_fill_recursive(const aligned_t *dest);
 int qthread_syncvar_fill(syncvar_t *restrict dest);
 
 /* These functions wait for memory to become empty, and then fill it. When
@@ -553,6 +554,10 @@ int qthread_readXX(aligned_t       *dest,
  */
 int qthread_lock(const aligned_t *a);
 int qthread_unlock(const aligned_t *a);
+int qthread_lock_init(const aligned_t *a, const bool is_recursive);
+
+const int qthread_trylock(const aligned_t *a);
+
 
 #if defined(QTHREAD_MUTEX_INCREMENT) ||             \
     (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC32) || \

--- a/src/locks.c
+++ b/src/locks.c
@@ -16,6 +16,11 @@ int API_FUNC qthread_lock_init(const aligned_t *a, const bool is_recursive)
     return qthread_feb_adr_init(a, is_recursive);
 }                      /*}}} */
 
+int API_FUNC qthread_lock_destroy(aligned_t *a)
+{                      /*{{{ */
+    return qthread_feb_adr_remove(a);
+}  
+
 int API_FUNC qthread_lock(const aligned_t *a)
 {                      /*{{{ */
     return qthread_readFE(NULL, a);

--- a/src/locks.c
+++ b/src/locks.c
@@ -19,7 +19,7 @@ int API_FUNC qthread_lock_init(const aligned_t *a, const bool is_recursive)
 int API_FUNC qthread_lock_destroy(aligned_t *a)
 {                      /*{{{ */
     return qthread_feb_adr_remove(a);
-}  
+}                      /*}}} */
 
 int API_FUNC qthread_lock(const aligned_t *a)
 {                      /*{{{ */

--- a/src/locks.c
+++ b/src/locks.c
@@ -4,15 +4,26 @@
 
 /* The API */
 #include "qthread/qthread.h"
+#include "qt_feb.h"
 
 /* Internal Headers */
 #include "qt_visibility.h"
 
 /* functions to implement FEB-ish locking/unlocking*/
 
+int API_FUNC qthread_lock_init(const aligned_t *a, const bool is_recursive)
+{                      /*{{{ */
+    return qthread_feb_adr_init(a, is_recursive);
+}                      /*}}} */
+
 int API_FUNC qthread_lock(const aligned_t *a)
 {                      /*{{{ */
     return qthread_readFE(NULL, a);
+}                      /*}}} */
+
+const int API_FUNC qthread_trylock(const aligned_t *a)
+{                      /*{{{ */
+    return qthread_readFE_nb(NULL, a);
 }                      /*}}} */
 
 int API_FUNC qthread_unlock(const aligned_t *a)

--- a/test/stress/lock_acq_rel.c
+++ b/test/stress/lock_acq_rel.c
@@ -3,19 +3,47 @@
 #include <qthread/qthread.h>
 #include <qthread/qloop.h>
 
-static int64_t count = 0;
+static int64_t count;
 static aligned_t lock;
+bool is_recursive_lock = true;
 
-static void task(size_t start, size_t stop, void  *args_) {
+static void task_1(size_t start, size_t stop, void  *args_) {
   qthread_lock(&lock);
   count++;
+  qthread_unlock(&lock);
+}
+
+static void task_2(size_t start, size_t stop, void  *args_) {
+  qthread_lock(&lock);
+  qthread_lock(&lock);
+  count++;
+  qthread_unlock(&lock);
   qthread_unlock(&lock);
 }
 
 int main(int argc, char *argv[]) {
     uint64_t iters = 1000000l;
     assert(qthread_initialize() == 0);
-    qt_loop(0, iters, task, NULL);
+
+    /* Simple lock acquire and release */
+    count = 0;
+    qt_loop(0, iters, task_1, NULL);
     assert(iters == count);
+
+    /* Recursive lock acquire and release, no recursion */
+    qthread_lock_init(&lock, is_recursive_lock);
+    {
+      /* Recursive lock acquire and release, no recursion */
+      count = 0;
+      qt_loop(0, iters, task_1, NULL);
+      assert(iters == count);
+    
+      /* Recursive lock acquire and release */
+      count = 0;
+      qt_loop(0, iters, task_2, NULL);
+      assert(iters == count);
+    }
+    qthread_lock_destroy(&lock);
+
     return 0;
 }

--- a/test/stress/lock_acq_rel.c
+++ b/test/stress/lock_acq_rel.c
@@ -2,10 +2,14 @@
 #include <stdio.h>
 #include <qthread/qthread.h>
 #include <qthread/qloop.h>
+#include <pthread.h>
 
 static int64_t count;
 static aligned_t lock;
 bool is_recursive_lock = true;
+bool is_not_recursive_lock = false;
+
+pthread_mutex_t count_mutex;
 
 static void task_1(size_t start, size_t stop, void  *args_) {
   qthread_lock(&lock);
@@ -22,7 +26,7 @@ static void task_2(size_t start, size_t stop, void  *args_) {
 }
 
 int main(int argc, char *argv[]) {
-    uint64_t iters = 1000000l;
+    uint64_t iters = 4l;
     assert(qthread_initialize() == 0);
 
     /* Simple lock acquire and release */


### PR DESCRIPTION
This implements a recursive lock using FEBs. The idea is that `qthreade_read_FE` becomes re-entrant if `qthread_read_FE` is called from `qthread_lock` and `qthread_lock_init` has been called on the same address setting `is_recursive` to true. Analogously, `qthread_unlock` calls `qthead_fill` which decrements a counter of a recursive lock. If the counter reaches zero, blocked waiters (EFQ) are unblocked. 

Uses of other FEB calls over recursive locks are unsupported and we could error out. Currently they have no effect but could lead to programming errors if programmer expects FEB synchronization over an address used for a recursive lock.

Todo
- [ ] Add unit test
- [ ] Error out in incorrect use
- [ ] Update qthread_feb_blocker_func to use proper func name

With this infrastructure, we should be able to support ULTs from Open MPI. 
For Open MPI, we'd need then these changes:
https://github.com/janciesko/ompi/commit/daef600cee3ed9607f10829c5dc3b4de5da0bc4c
https://github.com/janciesko/ompi/commit/bab853bf53355c6fbe71f24a4321bf19293d1165