### PR TITLE
 [WIP] Add support for recursive locks and try_lock (using spinlocks)

### DIFF
--- a/include/qt_hash.h
+++ b/include/qt_hash.h
@@ -14,10 +14,14 @@
 extern "C" {
 #endif
 
+#define PUT_COLLISION 0
+#define PUT_SUCCESS   1
+
 typedef const void *qt_key_t;
 typedef struct qt_hash_s *qt_hash;
 typedef void (*qt_hash_callback_fn)(const qt_key_t, void *, void *);
 typedef void (*qt_hash_deallocator_fn)(void *);
+
 
 void qt_hash_initialize_subsystem(void);
 

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -320,7 +320,6 @@ qthread_worker_id_t   qthread_worker_local(qthread_shepherd_id_t *s);
 void *   qthread_get_tasklocal(unsigned int);
 unsigned qthread_size_tasklocal(void);
 
-
 void* qthread_tos(void);
 void* qthread_bos(void);
 

--- a/include/qthread/qthread.h
+++ b/include/qthread/qthread.h
@@ -6,6 +6,7 @@
 #include <limits.h>                    /* for UINT_MAX (C89) */
 #include "qthread-int.h"               /* for uint32_t and uint64_t */
 #include "common.h"                    /* important configuration options */
+#include <stdbool.h> 
 
 #include <string.h>                    /* for memcpy() */
 
@@ -553,6 +554,14 @@ int qthread_readXX(aligned_t       *dest,
  */
 int qthread_lock(const aligned_t *a);
 int qthread_unlock(const aligned_t *a);
+int qthread_trylock(const aligned_t *a);
+
+/* functions to implement spinlock-based locking/unlocking 
+ * if qthread_lock_init(adr) is called, subsequent locking over adr 
+ * uses spin locking instead of FEBs. Support recursive locking.
+ */
+int qthread_lock_init(const aligned_t *a, const bool is_recursive); 
+int qthread_lock_destroy(aligned_t *a);
 
 #if defined(QTHREAD_MUTEX_INCREMENT) ||             \
     (QTHREAD_ASSEMBLY_ARCH == QTHREAD_POWERPC32) || \

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -204,8 +204,6 @@ void INTERNAL qt_hash_destroy_deallocate(qt_hash                h,
     qt_hash_destroy(h);
 } /*}}}*/
 
-#define PUT_COLLISION 0
-#define PUT_SUCCESS   1
 int INTERNAL qt_hash_put(qt_hash  h,
                          qt_key_t key,
                          void    *value)

--- a/src/locks.c
+++ b/src/locks.c
@@ -4,20 +4,222 @@
 
 /* The API */
 #include "qthread/qthread.h"
+#include <qthread/hash.h>
 
 /* Internal Headers */
 #include "qt_visibility.h"
+#include "qt_atomics.h"
+#include "qt_hash.h"
+#include "qt_alloc.h"
+#include "qt_feb.h"
 
-/* functions to implement FEB-ish locking/unlocking*/
+#include <stdbool.h> 
+#include <assert.h>
+
+#define SPINLOCK_IS_RECURSIVE (-1)
+#define SPINLOCK_IS_NOT_RECURSIVE (-2)
+//typedef struct qt_hash_s qt_hash;
+                              
+typedef struct {
+    int64_t s;
+    int64_t count;
+} qthread_spinlock_state_t;
+
+typedef struct {
+    qt_spin_trylock_t lock;
+    qthread_spinlock_state_t state;
+} qthread_spinlock_t;
+
+#define QTHREAD_CHOOSE_STRIPE2(addr) (qt_hash64((uint64_t)(uintptr_t)addr) & (QTHREAD_LOCKING_STRIPES - 1))
+#define LOCKBIN(key) QTHREAD_CHOOSE_STRIPE2(key)
+extern unsigned int QTHREAD_LOCKING_STRIPES;
+
+qt_hash * spinlock_buckets;    
+
+static void qthread_spinlock_destroy_fn(qthread_spinlock_t *l) {
+    QTHREAD_TRYLOCK_DESTROY_PTR(&l->lock);
+}  
+
+INTERNAL qthread_spinlock_t * lock_hashmap_get(const aligned_t * key) {
+    if(!spinlock_buckets)
+        return NULL;
+
+    return  qt_hash_get(spinlock_buckets[LOCKBIN(key)], key);
+}
+
+INTERNAL int lock_hashmap_put(const aligned_t * key, qthread_spinlock_t * val) {
+    if(!spinlock_buckets)
+        return QTHREAD_OPFAIL;
+    
+    if (PUT_SUCCESS == qt_hash_put(spinlock_buckets[LOCKBIN(key)], key, val))
+        return QTHREAD_SUCCESS;
+
+    return QTHREAD_OPFAIL;
+}
+
+INTERNAL int lock_hashmap_remove(const aligned_t * key) {
+    if(!spinlock_buckets)
+        return QTHREAD_OPFAIL;
+    
+    if (qt_hash_remove(spinlock_buckets[LOCKBIN(key)], key))
+        return QTHREAD_SUCCESS;
+
+    return QTHREAD_OPFAIL;
+}
+
+INTERNAL bool qthread_is_spin_lock(const aligned_t * a) {
+    return (NULL != lock_hashmap_get(a));
+}
+
+INTERNAL int qthread_spinlock_init(const aligned_t * a, const bool is_recursive) {
+    uint_fast8_t need_sync = 1;
+
+    if(!spinlock_buckets){
+       spinlock_buckets = (qt_hash*) qt_malloc (sizeof(qt_hash) * QTHREAD_LOCKING_STRIPES);
+       assert(spinlock_buckets);
+       for (unsigned i = 0; i < QTHREAD_LOCKING_STRIPES; i++) {
+            spinlock_buckets[i] = qt_hash_create(need_sync);
+            assert(spinlock_buckets[i]);
+        }
+    }
+
+    if (!qthread_is_spin_lock(a)) {
+        qthread_spinlock_t * l = qt_malloc (sizeof(qthread_spinlock_t));
+        assert(l);
+        l->state.s = is_recursive ? SPINLOCK_IS_RECURSIVE : SPINLOCK_IS_NOT_RECURSIVE;
+        l->state.count = 0;
+        QTHREAD_TRYLOCK_INIT_PTR(&l->lock);
+        lock_hashmap_put(a, l);
+        return QTHREAD_SUCCESS;
+    }
+    return QTHREAD_OPFAIL;
+}
+
+INTERNAL int qthread_spinlock_destroy(const aligned_t * a) {
+    return lock_hashmap_remove(a);
+}
+
+INTERNAL int qthread_spinlock_finalize() {
+    if(spinlock_buckets){
+        for (unsigned i = 0; i < QTHREAD_LOCKING_STRIPES; i++) {
+            assert(spinlock_buckets[i]);
+            qt_hash_destroy_deallocate(spinlock_buckets[i],
+                            (qt_hash_deallocator_fn)
+                            qthread_spinlock_destroy_fn);
+        }
+        qt_free(spinlock_buckets);
+    }
+    return QTHREAD_SUCCESS;
+}
+
+INTERNAL int qthread_spinlock_lock(const aligned_t * a) {
+    qthread_spinlock_t * l = lock_hashmap_get(a);
+    if (l != NULL) {
+        if (l->state.s >= SPINLOCK_IS_RECURSIVE) {
+            if(l->state.s == qthread_readstate(CURRENT_UNIQUE_WORKER)){ // Reentrant
+                ++l->state.count;
+                MACHINE_FENCE;
+            }else {
+                QTHREAD_TRYLOCK_LOCK(&l->lock);
+                l->state.s = qthread_readstate(CURRENT_UNIQUE_WORKER);
+                ++l->state.count;
+                MACHINE_FENCE;
+            }     
+        } else {
+            QTHREAD_TRYLOCK_LOCK(&l->lock);
+        }
+        return QTHREAD_SUCCESS;
+    }
+    return QTHREAD_OPFAIL;
+}
+
+INTERNAL int qthread_spinlock_trylock(const aligned_t * a) {
+    qthread_spinlock_t * l = lock_hashmap_get(a);
+    if (l != NULL) {
+        if (l->state.s >= SPINLOCK_IS_RECURSIVE) {
+            if(l->state.s == qthread_readstate(CURRENT_UNIQUE_WORKER)){ // Reentrant
+                ++l->state.count;
+                MACHINE_FENCE;
+            }else {
+                if(QTHREAD_TRYLOCK_TRY(&l->lock)) {
+                    l->state.s = qthread_readstate(CURRENT_UNIQUE_WORKER);
+                    ++l->state.count;
+                    MACHINE_FENCE;
+                } else {
+                    return QTHREAD_OPFAIL;
+                }
+            }     
+        } else {
+            return QTHREAD_TRYLOCK_TRY(&l->lock);
+            
+        }
+        return QTHREAD_SUCCESS;
+    }
+    return QTHREAD_OPFAIL;
+}
+
+INTERNAL int qthread_spinlock_unlock(const aligned_t * a) {
+    qthread_spinlock_t * l = lock_hashmap_get(a);
+    if (l != NULL) {
+        if (l->state.s >= SPINLOCK_IS_RECURSIVE) {
+            if(l->state.s == qthread_readstate(CURRENT_UNIQUE_WORKER)){
+                --l->state.count;
+                if(!l->state.count) {
+                    l->state.s = SPINLOCK_IS_RECURSIVE; // Reset
+                    MACHINE_FENCE;
+                    QTHREAD_TRYLOCK_UNLOCK(&l->lock); 
+                }
+            }else {
+                if(l->state.count)
+                    return QTHREAD_OPFAIL;
+            }
+        } else {
+            QTHREAD_TRYLOCK_UNLOCK(&l->lock);
+        }
+        return QTHREAD_SUCCESS;
+    }
+    return QTHREAD_OPFAIL;
+}
+
+/* Functions to implement FEB-ish locking/unlocking*/
+
+int API_FUNC qthread_lock_init(const aligned_t *a, const bool is_recursive)
+{                      /*{{{ */
+    return qthread_spinlock_init(a, is_recursive);
+}                      /*}}} */
+
+int API_FUNC qthread_lock_destroy(aligned_t *a)
+{                      /*{{{ */
+    if (!qthread_is_spin_lock(a)) {
+        return QTHREAD_SUCCESS;
+    }
+    return qthread_spinlock_destroy(a);
+}                      /*}}} */
 
 int API_FUNC qthread_lock(const aligned_t *a)
 {                      /*{{{ */
-    return qthread_readFE(NULL, a);
+    if (!qthread_is_spin_lock(a)) {
+        return qthread_readFE(NULL, a);
+    }
+    return qthread_spinlock_lock(a);
+}                      /*}}} */
+
+const int API_FUNC qthread_trylock(const aligned_t *a)
+{                      /*{{{ */
+    if (!qthread_is_spin_lock(a)){
+        return qthread_readFE_nb(NULL, a);
+    }
+    return qthread_spinlock_trylock(a);
 }                      /*}}} */
 
 int API_FUNC qthread_unlock(const aligned_t *a)
 {                      /*{{{ */
-    return qthread_fill(a);
+    if (!qthread_is_spin_lock(a)) {
+        return qthread_fill(a);
+    }
+    return qthread_spinlock_unlock(a);
 }                      /*}}} */
+
+#undef qt_hash_t
 
 /* vim:set expandtab: */

--- a/src/locks.c
+++ b/src/locks.c
@@ -18,7 +18,6 @@
 
 #define SPINLOCK_IS_RECURSIVE (-1)
 #define SPINLOCK_IS_NOT_RECURSIVE (-2)
-//typedef struct qt_hash_s qt_hash;
                               
 typedef struct {
     int64_t s;
@@ -204,7 +203,7 @@ int API_FUNC qthread_lock(const aligned_t *a)
     return qthread_spinlock_lock(a);
 }                      /*}}} */
 
-const int API_FUNC qthread_trylock(const aligned_t *a)
+int API_FUNC qthread_trylock(const aligned_t *a)
 {                      /*{{{ */
     if (!qthread_is_spin_lock(a)){
         return qthread_readFE_nb(NULL, a);

--- a/src/qthread.c
+++ b/src/qthread.c
@@ -84,6 +84,7 @@
 #include "qt_subsystems.h"
 #include "qt_output_macros.h"
 #include "qt_int_log.h"
+#include "qt_hash.h"
 
 
 #if !(defined(HAVE_GCC_INLINE_ASSEMBLY) &&              \
@@ -130,6 +131,9 @@ int GUARD_PAGES = 1;
 #else
 #define GUARD_PAGES 0
 #endif
+
+extern qt_hash * spinlock_buckets;
+extern int INTERNAL qthread_spinlock_finalize();
 
 /* Internal Prototypes */
 #ifdef QTHREAD_MAKECONTEXT_SPLIT
@@ -1006,9 +1010,13 @@ int API_FUNC qthread_initialize(void)
         qlib->shepherds[i].uniquelockaddrs = qt_hash_create(need_sync);
         qlib->shepherds[i].uniquefebaddrs  = qt_hash_create(need_sync);
 #endif
+        
 
         qthread_debug(SHEPHERD_DETAILS, "shepherd %i set up (%p)\n", i, &qlib->shepherds[i]);
     }
+
+    spinlock_buckets = NULL;
+
     qthread_debug(SHEPHERD_DETAILS, "done setting up shepherds.\n");
 
 /* now, transform the current main context into a qthread,
@@ -1564,6 +1572,8 @@ void API_FUNC qthread_finalize(void)
     }
     qthread_debug(CORE_DETAILS, "freeing shep0's threadqueue\n");
     qt_threadqueue_free(shep0->ready);
+
+    qthread_spinlock_finalize();
 
     qthread_debug(CORE_DETAILS, "calling cleanup functions\n");
     while (qt_cleanup_funcs != NULL) {

--- a/src/qthread.c
+++ b/src/qthread.c
@@ -132,8 +132,9 @@ int GUARD_PAGES = 1;
 #define GUARD_PAGES 0
 #endif
 
-extern qt_hash * spinlock_buckets;
+//extern qt_hash * qthread_spinlock_buckets;
 extern int INTERNAL qthread_spinlock_finalize();
+extern int INTERNAL qthread_spinlock_initialize();
 
 /* Internal Prototypes */
 #ifdef QTHREAD_MAKECONTEXT_SPLIT
@@ -1015,7 +1016,7 @@ int API_FUNC qthread_initialize(void)
         qthread_debug(SHEPHERD_DETAILS, "shepherd %i set up (%p)\n", i, &qlib->shepherds[i]);
     }
 
-    spinlock_buckets = NULL;
+    qthread_spinlock_initialize();
 
     qthread_debug(SHEPHERD_DETAILS, "done setting up shepherds.\n");
 

--- a/test/stress/lock_acq_rel.c
+++ b/test/stress/lock_acq_rel.c
@@ -2,20 +2,53 @@
 #include <stdio.h>
 #include <qthread/qthread.h>
 #include <qthread/qloop.h>
+#include <pthread.h>
 
-static int64_t count = 0;
+
+static int64_t count;
 static aligned_t lock;
+bool is_recursive_lock = true;
+bool is_not_recursive_lock = false;
 
-static void task(size_t start, size_t stop, void  *args_) {
+pthread_mutex_t count_mutex;
+
+static void task_1(size_t start, size_t stop, void  *args_) {
   qthread_lock(&lock);
   count++;
+  qthread_unlock(&lock);
+}
+
+static void task_2(size_t start, size_t stop, void  *args_) {
+  qthread_lock(&lock);
+  qthread_lock(&lock);
+  count++;
+  qthread_unlock(&lock);
   qthread_unlock(&lock);
 }
 
 int main(int argc, char *argv[]) {
     uint64_t iters = 1000000l;
     assert(qthread_initialize() == 0);
-    qt_loop(0, iters, task, NULL);
+
+    /* Simple lock acquire and release */
+    count = 0;
+    qt_loop(0, iters, task_1, NULL);
     assert(iters == count);
+
+    /* Recursive lock acquire and release, no recursion */
+    qthread_lock_init(&lock, is_recursive_lock);
+    {
+      /* Recursive lock acquire and release, no recursion */
+      count = 0;
+      qt_loop(0, iters, task_1, NULL);
+      assert(iters == count);
+    
+      /* Recursive lock acquire and release */
+      count = 0;
+      qt_loop(0, iters, task_2, NULL);
+      assert(iters == count);
+    }
+    qthread_lock_destroy(&lock);
+
     return 0;
 }


### PR DESCRIPTION
This is another implementation using hashmaps of spinlocks and likely the way to go. Needs a bit of work
- [x] unit test
- [x] fix compilation errors
- [x] test on x86
- [x] test on PowerISA 
- [x] test on ARM64
- [x] test on MAC(x86,ARM64)

With this infrastructure, we should be able to support ULTs from Open MPI.
For Open MPI, we'd need then these changes:
https://github.com/janciesko/ompi/commit/daef600cee3ed9607f10829c5dc3b4de5da0bc4c
https://github.com/janciesko/ompi/commit/bab853bf53355c6fbe71f24a4321bf19293d1165
