### PR TITLE
Merge tests which verify floating points registers save/restore during context switch

### DIFF
--- a/include/fastcontext/arm-ucontext.h
+++ b/include/fastcontext/arm-ucontext.h
@@ -20,9 +20,7 @@ struct mctxt {
     /* Saved main processor registers. */
 #ifdef NEEDARMA64CONTEXT
 	uint64_t regs[32]; /* callee saves x0-x30, SP */
-	#ifdef ARMA64_CONTEXT_SWITCH_NEON_REGS
-	uint128_t regs[32]; /* SIMD Neon Registers*/
-	#endif
+	uint64_t fpu_regs[64]; /* 32 128bit FPU/SIMD Neon Registers */
 #else
     uint32_t regs[16]; /* callee saves r0-r15 */
 #endif

--- a/src/fastcontext/asm.S
+++ b/src/fastcontext/asm.S
@@ -821,12 +821,11 @@ GET:
         stp     X25, X26, [X0,#200]  
         stp     X27, X28, [X0,#216]
         stp     X29, X30, [X0,#232]     /* X30 is LR */
-	mov	X29, SP
+        mov     X29, SP
         str     X29, [X0,#248]           /* sp, not sure if ARMv8 allows storing SP directly */
-	ldr	X29, [X0,#232]		/* restore FP just to be safe */
+        ldr     X29, [X0,#232]           /* restore FP just to be safe */
 
-#ifdef ARMA64_CONTEXT_SWITCH_NEON_REGS
-        /* Store vector registers */
+        /* Store fpu/vector registers */
         add     X0, X0, #256            /* Update pointer to avoid immediate growing to large for STP/LDP instruction */
         stp     Q0, Q1, [X0]
         stp     Q2, Q3, [X0,#32]
@@ -845,14 +844,14 @@ GET:
         stp     Q28, Q29, [X0,#448]
         stp     Q30, Q31, [X0,#480]
         sub     X0, X0, #256
-#endif
+
         /* Store 1 as X0-to-restore */
         mov     X1, #1
         str     X1, [X0]                
         
         /* return 0 */
         mov     X0, #0
-	ret
+        ret
 
 /*
  * TODO: add vector registers for both NEON and SVE
@@ -883,11 +882,10 @@ SET:
         ldp     X25, X26, [X0,#200]  
         ldp     X27, X28, [X0,#216]
         ldr     X29, [X0,#248]
-	mov	SP, X29
-	ldp	X29, X30, [X0,#232]
+        mov	SP, X29
+        ldp	X29, X30, [X0,#232]
         
-#ifdef ARMA64_CONTEXT_SWITCH_NEON_REG
-        /* Load vector registers */
+        /* Load fpu/vector registers */
         add     X0, X0, #256
         ldp     Q0, Q1, [X0]
         ldp     Q2, Q3, [X0,#32]
@@ -906,7 +904,6 @@ SET:
         ldp     Q28, Q29, [X0,#448]
         ldp     Q30, Q31, [X0,#480]
         sub     X0, X0, #256
-#endif
         ldr     X0, [X0]
 	ret
 #endif

--- a/test/basics/qthread_fp.c
+++ b/test/basics/qthread_fp.c
@@ -16,7 +16,7 @@ struct parts
   int length;
   float exp;
   float ans;
-  aligned_t cond;
+  aligned_t cond[2];
 };
 
 // https://www.w3resource.com/c-programming-exercises/math/c-math-exercise-24.php
@@ -26,6 +26,7 @@ static float taylor_exponential_core(int n, float x)
   for (int i = n - 1; i > 0; --i)
   {
     exp_sum = 1 + x * exp_sum / i;
+    qthread_yield();
   }
   return exp_sum;
 }
@@ -43,12 +44,12 @@ static void checkFloatAsQthread()
 {
   int ret = -1;
   struct parts teParts = {250, 9.0f, 0.0f};
-  qthread_empty(&teParts.cond);
+  qthread_empty(&teParts.cond[0]);
 
-  ret = qthread_fork(taylor_exponential, &teParts, &teParts.cond);
+  ret = qthread_fork(taylor_exponential, &teParts, &teParts.cond[0]);
   assert(ret == QTHREAD_SUCCESS);
 
-  ret = qthread_readFF(NULL, &teParts.cond);
+  ret = qthread_readFF(NULL, &teParts.cond[0]);
   assert(ret == QTHREAD_SUCCESS);
 
   assert(teParts.ans == 8103.083984f);

--- a/test/basics/qthread_fp.c
+++ b/test/basics/qthread_fp.c
@@ -16,7 +16,7 @@ struct parts
   int length;
   float exp;
   float ans;
-  aligned_t cond[2];
+  aligned_t cond;
 };
 
 // https://www.w3resource.com/c-programming-exercises/math/c-math-exercise-24.php
@@ -40,16 +40,31 @@ static aligned_t taylor_exponential(void *arg)
   return 0;
 }
 
+static aligned_t checkFloatAsQthreads()
+{
+  struct parts teParts = {250, 9.0f, 0.0f};
+  qthread_empty(&teParts.cond);
+
+  struct parts teParts1 = {50, 9.0f, 0.0f};
+  qthread_empty(&teParts1.cond);
+  
+  struct parts teParts2 = {9, 9.0f, 0.0f};
+  qthread_empty(&teParts2.cond);
+
+  return 0;
+
+}
+
 static void checkFloatAsQthread()
 {
   int ret = -1;
   struct parts teParts = {250, 9.0f, 0.0f};
-  qthread_empty(&teParts.cond[0]);
+  qthread_empty(&teParts.cond);
 
-  ret = qthread_fork(taylor_exponential, &teParts, &teParts.cond[0]);
+  ret = qthread_fork(taylor_exponential, &teParts, &teParts.cond);
   assert(ret == QTHREAD_SUCCESS);
 
-  ret = qthread_readFF(NULL, &teParts.cond[0]);
+  ret = qthread_readFF(NULL, &teParts.cond);
   assert(ret == QTHREAD_SUCCESS);
 
   assert(teParts.ans == 8103.083984f);

--- a/test/basics/qthread_fp.c
+++ b/test/basics/qthread_fp.c
@@ -1,0 +1,70 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <qthread/qthread.h>
+
+
+// https://www.geeksforgeeks.org/comparison-float-value-c/
+// https://dotnettutorials.net/lesson/taylor-series-using-recursion-in-c/
+// https://www.studytonight.com/c/programs/important-concepts/sum-of-taylor-series
+
+struct parts
+{
+  int length;
+  float exp;
+  float ans;
+  aligned_t* cond;
+};
+
+// https://www.w3resource.com/c-programming-exercises/math/c-math-exercise-24.php
+static float taylor_exponential_core(int n, float x)
+{
+  float exp_sum = 1;
+  for (int i = n - 1; i > 0; --i)
+  {
+    exp_sum = 1 + x * exp_sum / i;
+  }
+  return exp_sum;
+}
+
+static aligned_t taylor_exponential(void *arg)
+{
+  struct parts* te = (struct parts*) arg;
+  float exp = te->exp;
+  float length = te->length;
+  te->ans = taylor_exponential_core(te->length, te->exp);
+  return 0;
+}
+
+static void checkFloat()
+{
+  void* cond = malloc(QTHREAD_SIZEOF_ALIGNED_T);
+  struct parts teParts = {250,9.0f,0.0f, cond};
+  int ret = -1;
+  qthread_empty(teParts.cond);
+
+  ret = qthread_fork(taylor_exponential, &teParts, teParts.cond);
+  assert(ret == QTHREAD_SUCCESS);
+
+  ret = qthread_readFF(NULL, teParts.cond);
+  assert(ret == QTHREAD_SUCCESS);
+
+  printf("value of ans = %f\n", teParts.ans);
+}
+
+int main(void)
+{
+  float ans = taylor_exponential_core(250, 9.0);
+  printf("value of ans = %f\n", ans);
+  assert(ans == 8103.083984f);
+
+  int status = qthread_initialize();
+  assert(status == QTHREAD_SUCCESS);
+
+  checkFloat();
+  return EXIT_SUCCESS;
+}

--- a/test/basics/qthread_fp.c
+++ b/test/basics/qthread_fp.c
@@ -7,7 +7,6 @@
 #include <assert.h>
 #include <qthread/qthread.h>
 
-
 // https://www.geeksforgeeks.org/comparison-float-value-c/
 // https://dotnettutorials.net/lesson/taylor-series-using-recursion-in-c/
 // https://www.studytonight.com/c/programs/important-concepts/sum-of-taylor-series
@@ -17,7 +16,7 @@ struct parts
   int length;
   float exp;
   float ans;
-  aligned_t* cond;
+  aligned_t cond;
 };
 
 // https://www.w3resource.com/c-programming-exercises/math/c-math-exercise-24.php
@@ -33,38 +32,41 @@ static float taylor_exponential_core(int n, float x)
 
 static aligned_t taylor_exponential(void *arg)
 {
-  struct parts* te = (struct parts*) arg;
+  struct parts *te = (struct parts *)arg;
   float exp = te->exp;
   float length = te->length;
   te->ans = taylor_exponential_core(te->length, te->exp);
   return 0;
 }
 
+static void checkFloatAsQthread()
+{
+  int ret = -1;
+  struct parts teParts = {250, 9.0f, 0.0f};
+  qthread_empty(&teParts.cond);
+
+  ret = qthread_fork(taylor_exponential, &teParts, &teParts.cond);
+  assert(ret == QTHREAD_SUCCESS);
+
+  ret = qthread_readFF(NULL, &teParts.cond);
+  assert(ret == QTHREAD_SUCCESS);
+
+  assert(teParts.ans == 8103.083984f);
+}
+
 static void checkFloat()
 {
-  void* cond = malloc(QTHREAD_SIZEOF_ALIGNED_T);
-  struct parts teParts = {250,9.0f,0.0f, cond};
-  int ret = -1;
-  qthread_empty(teParts.cond);
-
-  ret = qthread_fork(taylor_exponential, &teParts, teParts.cond);
-  assert(ret == QTHREAD_SUCCESS);
-
-  ret = qthread_readFF(NULL, teParts.cond);
-  assert(ret == QTHREAD_SUCCESS);
-
-  printf("value of ans = %f\n", teParts.ans);
+  float ans = taylor_exponential_core(250, 9.0f);
+  assert(ans == 8103.083984f);
 }
 
 int main(void)
 {
-  float ans = taylor_exponential_core(250, 9.0);
-  printf("value of ans = %f\n", ans);
-  assert(ans == 8103.083984f);
+  checkFloat();
 
   int status = qthread_initialize();
   assert(status == QTHREAD_SUCCESS);
-
-  checkFloat();
+  checkFloatAsQthread();
+  
   return EXIT_SUCCESS;
 }

--- a/test/basics/qthread_fp_double.c
+++ b/test/basics/qthread_fp_double.c
@@ -1,0 +1,110 @@
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <qthread/qthread.h>
+
+// https://www.geeksforgeeks.org/comparison-float-value-c/
+// https://dotnettutorials.net/lesson/taylor-series-using-recursion-in-c/
+// https://www.studytonight.com/c/programs/important-concepts/sum-of-taylor-series
+
+struct parts
+{
+  int length;
+  double exp;
+  double ans;
+  aligned_t cond;
+};
+
+// https://www.w3resource.com/c-programming-exercises/math/c-math-exercise-24.php
+static double taylor_exponential_core(int n, double x)
+{
+  double exp_sum = 1;
+  for (int i = n - 1; i > 0; --i)
+  {
+    exp_sum = 1 + x * exp_sum / i;
+    qthread_yield();
+  }
+  return exp_sum;
+}
+
+static aligned_t taylor_exponential(void *arg)
+{
+  struct parts *te = (struct parts *)arg;
+  double exp = te->exp;
+  double length = te->length;
+  te->ans = taylor_exponential_core(te->length, te->exp);
+  return 0;
+}
+
+static void startQthread(struct parts *teParts)
+{
+  qthread_empty(&teParts->cond);
+
+  int ret = qthread_fork(taylor_exponential, teParts, &teParts->cond);
+  assert(ret == QTHREAD_SUCCESS);
+}
+
+static aligned_t checkDoubleAsQthreads()
+{
+  struct parts teParts1 = {250, 9.0, 0.0};
+  struct parts teParts2 = {50, 3.0, 0.0};
+  struct parts teParts3 = {150, 11.0, 0.0};
+
+  startQthread(&teParts1);
+  startQthread(&teParts2);
+  startQthread(&teParts3);
+
+  int ret = qthread_readFF(NULL, &teParts1.cond);
+  assert(ret == QTHREAD_SUCCESS);
+
+  ret = qthread_readFF(NULL, &teParts2.cond);
+  assert(ret == QTHREAD_SUCCESS);
+
+  ret = qthread_readFF(NULL, &teParts3.cond);
+  assert(ret == QTHREAD_SUCCESS);
+
+  assert(teParts1.ans == 8103.0839275753824);
+
+  assert(teParts2.ans == 20.085536923187668);
+
+  assert(teParts3.ans == 59874.141715197809);
+
+  return 0;
+}
+
+static void checkDoubleAsQthread()
+{
+  int ret = -1;
+  struct parts teParts = {250, 9.0, 0.0};
+  qthread_empty(&teParts.cond);
+
+  ret = qthread_fork(taylor_exponential, &teParts, &teParts.cond);
+  assert(ret == QTHREAD_SUCCESS);
+
+  ret = qthread_readFF(NULL, &teParts.cond);
+  assert(ret == QTHREAD_SUCCESS);
+
+  assert(teParts.ans == 8103.0839275753824);
+}
+
+static void checkDouble()
+{
+  double ans = taylor_exponential_core(250, 9.0);
+  assert(ans == 8103.0839275753824);
+}
+
+int main(void)
+{
+  checkDouble();
+
+  int status = qthread_initialize();
+  assert(status == QTHREAD_SUCCESS);
+
+  checkDoubleAsQthread();
+  checkDoubleAsQthreads();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
I added two units tests which utilize FP registers and context switch. This should allow code to use the GP registers or FP registers without an issue. Note, this code tests the use of the floating point registers (lower 64-bits) and not SIMD vector registers (upper 64-bits).