### PR TITLE
Define QTHREAD_ARM and include defines in config test

### DIFF
--- a/config/qthread_ia_cacheline.m4
+++ b/config/qthread_ia_cacheline.m4
@@ -16,6 +16,10 @@ AC_CACHE_CHECK([for x86 cache line size],
 #define QTHREAD_POWERPC64   7
 #define QTHREAD_SPARCV9_32  8
 #define QTHREAD_SPARCV9_64  9
+#define QTHREAD_TILEPRO	    10
+#define QTHREAD_TILEGX	    11
+#define QTHREAD_ARM         12
+#define QTHREAD_ARMV8_A64   13
 ],[
 int op = 1, eax, ebx, ecx, edx, cachelinesize;
 FILE *f;

--- a/include/qthread/common.h.in
+++ b/include/qthread/common.h.in
@@ -122,6 +122,7 @@
 #define QTHREAD_SPARCV9_64  9
 #define QTHREAD_TILEPRO	    10
 #define QTHREAD_TILEGX	    11
-#define QTHREAD_ARMV8_A64   12
+#define QTHREAD_ARM         12
+#define QTHREAD_ARMV8_A64   13
 
 #endif


### PR DESCRIPTION
This adds the definition of QTHREAD_ARM so it would not resolve to the same as QTHREAD_UNSUPPORTED in scenarios such as as `#if (QTHREAD_ASSEMBLY_ARCH == QTHREAD_ARM)`. 
This also updates definitions in the cacheline conf m4. 

```
/* Architecture defines */
#define QTHREAD_UNSUPPORTED 0
#define QTHREAD_IA32        1
#define QTHREAD_AMD64       2
#define QTHREAD_IA64        3
#define QTHREAD_ALPHA       4
#define QTHREAD_MIPS        5
#define QTHREAD_POWERPC32   6
#define QTHREAD_POWERPC64   7
#define QTHREAD_SPARCV9_32  8
#define QTHREAD_SPARCV9_64  9
#define QTHREAD_TILEPRO	    10
#define QTHREAD_TILEGX	    11
#define QTHREAD_ARM         12
#define QTHREAD_ARMV8_A64   13
```