### PR TITLE
More BSD CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -504,6 +504,30 @@ jobs:
   #            cd ..
   #        done
 
+  netbsd:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v6
+    - name: netbsd
+      uses: vmactions/netbsd-vm@v1
+      with:
+        copyback: false
+        release: "10.1"
+        run: |
+          pkg_add coreutils cmake
+          for sch in nemesis sherwood distrib
+          do
+              echo "********** Scheduler: $sch **********"
+              rm -rf build
+              mkdir build
+              cd build
+              cmake -DCMAKE_BUILD_TYPE=Release -DQTHREADS_SCHEDULER="$sch" -DQTHREADS_TOPOLOGY="no" -DQTHREADS_CONTEXT_SWAP_IMPL=system ..
+              make -j2 VERBOSE=1
+              CTEST_OUTPUT_ON_FAILURE=1 gtimeout --foreground -k 20s 4m make test VERBOSE=1
+              cd ..
+          done
+
   mac:
     continue-on-error: true
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -528,6 +528,36 @@ jobs:
               cd ..
           done
 
+  dragonflybsd:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v6
+    - name: netbsd
+      uses: vmactions/dragonflybsd-vm@v1
+      with:
+        copyback: false
+        release: "6.4.2"
+        run: |
+          pkg update
+          pkg install -y cmake
+          pkg install -y hwloc2
+          pkg install -y coreutils # to get gtimeout for CI. The built-in timeout sometimes fails to kill the process.
+          for sch in nemesis sherwood distrib
+          do
+              for topo in hwloc binders no
+              do
+                  echo "********** Scheduler: $sch, Topology: $topo **********"
+                  rm -rf build
+                  mkdir build
+                  cd build
+                  cmake -DCMAKE_BUILD_TYPE=Release -DQTHREADS_SCHEDULER="$sch" -DQTHREADS_TOPOLOGY="$topo" -DQTHREADS_CONTEXT_SWAP_IMPL=system ..
+                  make -j2 VERBOSE=1
+                  CTEST_OUTPUT_ON_FAILURE=1 gtimeout --foreground -k 20s 4m make test VERBOSE=1
+                  cd ..
+              done
+          done
+
   mac:
     continue-on-error: true
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -454,6 +454,9 @@ jobs:
   freebsd:
     runs-on: ubuntu-24.04
     continue-on-error: true
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
     steps:
     - uses: actions/checkout@v6
     - name: freebsd
@@ -461,6 +464,8 @@ jobs:
       with:
         copyback: false
         release: "15.0"
+        sync: scp
+        arch: ${{ matrix.arch }}
         run: |
           pkg install -y cmake
           pkg install -y hwloc2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -480,6 +480,30 @@ jobs:
               done
           done
 
+  #openbsd:
+  #  runs-on: ubuntu-latest
+  #  continue-on-error: true
+  #  steps:
+  #  - uses: actions/checkout@v6
+  #  - name: openbsd
+  #    uses: vmactions/openbsd-vm@v1
+  #    with:
+  #      copyback: false
+  #      release: "7.8"
+  #      run: |
+  #        pkg_add coreutils cmake
+  #        for sch in nemesis sherwood distrib
+  #        do
+  #            echo "********** Scheduler: $sch **********"
+  #            rm -rf build
+  #            mkdir build
+  #            cd build
+  #            cmake -DCMAKE_BUILD_TYPE=Release -DQTHREADS_SCHEDULER="$sch" -DQTHREADS_CONTEXT_SWAP_IMPL=system ..
+  #            make -j2 VERBOSE=1
+  #            CTEST_OUTPUT_ON_FAILURE=1 gtimeout --foreground -k 20s 4m make test VERBOSE=1
+  #            cd ..
+  #        done
+
   mac:
     continue-on-error: true
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -470,20 +470,31 @@ jobs:
           pkg install -y cmake
           pkg install -y hwloc2
           pkg install -y coreutils # to get gtimeout for CI. The built-in timeout sometimes fails to kill the process.
-          for sch in nemesis sherwood distrib
-          do
-              for topo in hwloc binders no
+          # running ARM this way is astonishingly slow, so only do one build config.
+          if [ "${{ matrix.arch }}" = "x86_64" ]
+          then
+              for sch in nemesis sherwood distrib
               do
-                  echo "********** Scheduler: $sch, Topology: $topo **********"
-                  rm -rf build
-                  mkdir build
-                  cd build
-                  cmake -DCMAKE_BUILD_TYPE=Release -DQTHREADS_SCHEDULER="$sch" -DQTHREADS_TOPOLOGY="$topo" -DQTHREADS_CONTEXT_SWAP_IMPL=system ..
-                  make -j2 VERBOSE=1
-                  CTEST_OUTPUT_ON_FAILURE=1 gtimeout --foreground -k 20s 4m make test VERBOSE=1
-                  cd ..
+                  for topo in hwloc binders no
+                  do
+                      echo "********** Scheduler: $sch, Topology: $topo **********"
+                      rm -rf build
+                      mkdir build
+                      cd build
+                      cmake -DCMAKE_BUILD_TYPE=Release -DQTHREADS_SCHEDULER="$sch" -DQTHREADS_TOPOLOGY="$topo" -DQTHREADS_CONTEXT_SWAP_IMPL=system ..
+                      make -j2 VERBOSE=1
+                      CTEST_OUTPUT_ON_FAILURE=1 gtimeout --foreground -k 20s 4m make test VERBOSE=1
+                      cd ..
+                  done
               done
-          done
+          else
+              mkdir build
+              cd build
+              cmake -DCMAKE_BUILD_TYPE=Release -DQTHREADS_SCHEDULER="nemesis" -DQTHREADS_TOPOLOGY="binders" -DQTHREADS_CONTEXT_SWAP_IMPL=system ..
+              make -j2 VERBOSE=1
+              CTEST_OUTPUT_ON_FAILURE=1 gtimeout --foreground -k 20s 4m make test VERBOSE=1
+              cd ..
+          fi
 
   #openbsd:
   #  runs-on: ubuntu-24.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -396,7 +396,7 @@ jobs:
       timeout-minutes: 40
 
   riscv:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
     - uses: actions/checkout@v6
@@ -425,7 +425,7 @@ jobs:
           done
 
   riscv-alpine:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
     - uses: actions/checkout@v6
@@ -452,7 +452,7 @@ jobs:
           done
 
   freebsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
     - uses: actions/checkout@v6
@@ -481,7 +481,7 @@ jobs:
           done
 
   #openbsd:
-  #  runs-on: ubuntu-latest
+  #  runs-on: ubuntu-24.04
   #  continue-on-error: true
   #  steps:
   #  - uses: actions/checkout@v6
@@ -505,7 +505,7 @@ jobs:
   #        done
 
   netbsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
     - uses: actions/checkout@v6
@@ -529,7 +529,7 @@ jobs:
           done
 
   dragonflybsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
     - uses: actions/checkout@v6

--- a/include/qt_atomic_wait.h
+++ b/include/qt_atomic_wait.h
@@ -215,7 +215,7 @@ while (0)
             (expected),                                                        \
             NULL,                                                              \
             NULL);                                                             \
-    while (0)
+  } while (0)
 #endif
 
 #define qt_wake_all(a)                                                         \

--- a/include/qt_atomic_wait.h
+++ b/include/qt_atomic_wait.h
@@ -193,6 +193,7 @@ while (0)
 #include <sys/futex.h>
 #include <sys/syscall.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #ifndef NDEBUG
 #define qt_wait_on_address(a, expected)                                        \

--- a/include/qt_atomics.h
+++ b/include/qt_atomics.h
@@ -127,19 +127,28 @@ static inline int QTHREAD_TRYLOCK_TRY(qt_spin_trylock_t *x) {
 #define QTHREAD_COND_DECL(c)                                                   \
   pthread_cond_t c;                                                            \
   pthread_mutex_t c##_lock
+// NetBSD is missing this part of the pthreads APIs, so bypass that bit.
+#ifdef __NetBSD__
+#define QT_MUTEXATTR_SETPSHARED_PRIVATE(attr)
+#define QT_CONDATTR_SETPSHARED_PRIVATE(attr)
+#else
+#define QT_MUTEXATTR_SETPSHARED_PRIVATE(attr)                                  \
+  qassert(pthread_mutexattr_setpshared((attr), PTHREAD_PROCESS_PRIVATE), 0)
+#define QT_CONDATTR_SETPSHARED_PRIVATE(attr)                                   \
+  qassert(pthread_condattr_setpshared((attr), PTHREAD_PROCESS_PRIVATE), 0)
+#endif
+
 #define QTHREAD_COND_INIT_SOLO(c)                                              \
   do {                                                                         \
     {                                                                          \
       pthread_mutexattr_t tmp_attr;                                            \
       qassert(pthread_mutexattr_init(&tmp_attr), 0);                           \
-      qassert(                                                                 \
-        pthread_mutexattr_setpshared(&tmp_attr, PTHREAD_PROCESS_PRIVATE), 0);  \
+      QT_MUTEXATTR_SETPSHARED_PRIVATE(&tmp_attr);                              \
       qassert(pthread_mutexattr_destroy(&tmp_attr), 0);                        \
     }                                                                          \
     {                                                                          \
       pthread_condattr_t tmp_attr;                                             \
-      qassert(pthread_condattr_setpshared(&tmp_attr, PTHREAD_PROCESS_PRIVATE), \
-              0);                                                              \
+      QT_CONDATTR_SETPSHARED_PRIVATE(&tmp_attr);                               \
       qassert(pthread_cond_init(&(c), &tmp_attr), 0);                          \
       qassert(pthread_condattr_destroy(&tmp_attr), 0);                         \
     }                                                                          \
@@ -149,14 +158,12 @@ static inline int QTHREAD_TRYLOCK_TRY(qt_spin_trylock_t *x) {
     {                                                                          \
       pthread_mutexattr_t tmp_attr;                                            \
       qassert(pthread_mutexattr_init(&tmp_attr), 0);                           \
-      qassert(                                                                 \
-        pthread_mutexattr_setpshared(&tmp_attr, PTHREAD_PROCESS_PRIVATE), 0);  \
+      QT_MUTEXATTR_SETPSHARED_PRIVATE(&tmp_attr);                              \
       qassert(pthread_mutexattr_destroy(&tmp_attr), 0);                        \
     }                                                                          \
     {                                                                          \
       pthread_condattr_t tmp_attr;                                             \
-      qassert(pthread_condattr_setpshared(&tmp_attr, PTHREAD_PROCESS_PRIVATE), \
-              0);                                                              \
+      QT_CONDATTR_SETPSHARED_PRIVATE(&tmp_attr);                               \
       qassert(pthread_cond_init((c), &tmp_attr), 0);                           \
       qassert(pthread_condattr_destroy(&tmp_attr), 0);                         \
     }                                                                          \
@@ -166,16 +173,14 @@ static inline int QTHREAD_TRYLOCK_TRY(qt_spin_trylock_t *x) {
     {                                                                          \
       pthread_mutexattr_t tmp_attr;                                            \
       qassert(pthread_mutexattr_init(&tmp_attr), 0);                           \
-      qassert(                                                                 \
-        pthread_mutexattr_setpshared(&tmp_attr, PTHREAD_PROCESS_PRIVATE), 0);  \
+      QT_MUTEXATTR_SETPSHARED_PRIVATE(&tmp_attr);                              \
       qassert(pthread_mutex_init(&(c##_lock), &tmp_attr), 0);                  \
       qassert(pthread_mutexattr_destroy(&tmp_attr), 0);                        \
     }                                                                          \
     {                                                                          \
       pthread_condattr_t tmp_attr;                                             \
       pthread_condattr_init(&tmp_attr);                                        \
-      qassert(pthread_condattr_setpshared(&tmp_attr, PTHREAD_PROCESS_PRIVATE), \
-              0);                                                              \
+      QT_CONDATTR_SETPSHARED_PRIVATE(&tmp_attr);                               \
       qassert(pthread_cond_init(&(c), &tmp_attr), 0);                          \
       qassert(pthread_condattr_destroy(&tmp_attr), 0);                         \
     }                                                                          \

--- a/include/qt_macros.h
+++ b/include/qt_macros.h
@@ -2,11 +2,13 @@
 #define QT_MACROS_H
 
 // Work around OSX currently refusing to support threads.h
+// OpenBSD and DragonflyBSD also run into this.
 #if 201112L <= __STDC_VERSION__ && __STDC_VERSION__ < 202311L
-#ifndef __STDC_NO_THREADS__
-#include <threads.h>
-#else
+#if defined(__STDC_NO_THREADS__) || defined(__OpenBSD__) ||                    \
+  defined(__DragonFly__)
 #define thread_local _Thread_local
+#else
+#include <threads.h>
 #endif
 #elif __STDC_VERSION__ < 201112L
 #error "C11 is required"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,12 +105,9 @@ set_target_properties(
 target_link_libraries(qthread PUBLIC Threads::Threads)
 
 # The c11 threading library has to be linked
-# via a separate library on BSD OSs.
+# via a separate library on FreeBSD-derived OSs.
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD" OR
-    "${CMAKE_SYSTEM_NAME}" STREQUAL "kFreeBSD" OR
-    "${CMAKE_SYSTEM_NAME}" STREQUAL "OpenBSD" OR
-    "${CMAKE_SYSTEM_NAME}" STREQUAL "NetBSD" OR
-    "${CMAKE_SYSTEM_NAME}" STREQUAL "DragonFly")
+    "${CMAKE_SYSTEM_NAME}" STREQUAL "kFreeBSD")
   target_link_libraries(qthread PUBLIC "stdthreads")
 endif()
 

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -5,7 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if defined(__STDC_NO_THREADS__)
+#if defined(__STDC_NO_THREADS__) || defined(__OpenBSD__) ||                    \
+  defined(__DragonFly__)
 #define QPOOL_USE_PTHREADS
 #endif
 


### PR DESCRIPTION
Try expanding the BSD CI builds. These are mostly excessive right now, but they may help us suss out bugs in the future as we (hopefully) shift toward the new futex wrappers, etc. since the BSD flavors have slightly different and unique flavors of the relevant syscalls.