### PR TITLE
Update Vendor Compiler Versions in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -173,7 +173,7 @@ jobs:
       run: |
         wget -O - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo apt-key add - && break || sleep 1
         sudo apt-add-repository 'deb https://apt.repos.intel.com/oneapi all main' && break || sleep 1
-        sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-2025.3
+        sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-2026.0
         source /opt/intel/oneapi/setvars.sh
         icx -v
     - name: build and test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -276,34 +276,33 @@ jobs:
         done
       timeout-minutes: 40
 
-  arm_acfl:
-    runs-on: ubuntu-22.04-arm
+  arm_atfl:
+    runs-on: ubuntu-24.04-arm
     continue-on-error: true
     env:
       CC: armclang
       CXX: armclang++
     steps:
     - uses: actions/checkout@v6
-    - name: install deps
+    - run: |
+        sudo apt-get install hwloc libhwloc-dev
+        hwloc-ls --version
+    - name: install gcc
       run: |
-        # Set up apt to get a more recent CMake directly from Kitware.
-        # This way it recognizes armclang.
-        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-        echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
-        sudo apt-get update -y
-        sudo apt-get install -y cmake
-        sudo apt-get install -y hwloc libhwloc-dev
-        wget -O acfl.tar https://developer.arm.com/-/cdn-downloads/permalink/Arm-Compiler-for-Linux/Version_24.10.1/arm-compiler-for-linux_24.10.1_Ubuntu-22.04_aarch64.tar
-        tar -vxf acfl.tar
-        ./arm-compiler-for-linux_24.10.1_Ubuntu-22.04/arm-compiler-for-linux_24.10.1_Ubuntu-22.04.sh -a -f -s acfl
-        rm acfl.tar
-        sudo apt install -y ./acfl/gcc-14.2.0_Ubuntu-22.04.deb ./acfl/arm-linux-compiler-24.10.1_Ubuntu-22.04.deb
-        rm -rf acfl
-        export PATH=$PATH:/opt/arm/arm-linux-compiler-24.10.1_Ubuntu-22.04/bin
-        armclang -v
+        sudo apt-get install gcc-14 g++-14
+    - name: install armclang
+      run: |
+        curl "https://developer.arm.com/packages/arm-toolchains:ubuntu-24/noble/Release.key" | sudo gpg --dearmor -o /usr/share/keyrings/obs-oss-arm-com.gpg
+        echo "deb [signed-by=/usr/share/keyrings/obs-oss-arm-com.gpg] https://developer.arm.com/packages/arm-toolchains:ubuntu-24/noble/ ./" | sudo tee /etc/apt/sources.list.d/obs-oss-arm-com.list
+        sudo apt update
+        sudo apt install arm-toolchains-transition
+        sudo apt update
+        sudo apt install arm-toolchain-for-linux
+        export PATH=$PATH:/opt/arm/arm-toolchain-for-linux/bin
+        armclang --version
     - name: build and test
       run: |
-        export PATH=$PATH:/opt/arm/arm-linux-compiler-24.10.1_Ubuntu-22.04/bin
+        export PATH=$PATH:/opt/arm/arm-toolchain-for-linux/bin
         for sch in nemesis sherwood distrib
         do
             for topo in hwloc binders no
@@ -318,7 +317,7 @@ jobs:
                 cd ..
             done
         done
-      timeout-minutes: 50
+      timeout-minutes: 40
 
   nvc:
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -155,6 +155,34 @@ jobs:
         done
       timeout-minutes: 40
 
+  # A relatively old Linux system that would still be expected to work.
+  linux-old:
+    runs-on: ubuntu-24.04
+    container: rockylinux:8
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v6
+    - run: |
+        dnf install -y gcc gcc-c++ cmake
+        dnf install -y --enablerepo=devel hwloc-devel
+    - name: build and test
+      run: |
+        for sch in nemesis sherwood distrib
+        do
+            for topo in hwloc binders no
+            do
+                echo "********** Scheduler: $sch, Topology: $topo **********"
+                rm -rf build
+                mkdir build
+                cd build
+                cmake -DCMAKE_BUILD_TYPE=Release -DQTHREADS_SCHEDULER="$sch" -DQTHREADS_TOPOLOGY="$topo" ..
+                make -j2 VERBOSE=1
+                CTEST_OUTPUT_ON_FAILURE=1 timeout -k 10s --foreground 12m make test VERBOSE=1
+                cd ..
+            done
+        done
+
+
   linux-icx:
     runs-on: ubuntu-24.04
     continue-on-error: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -339,12 +339,12 @@ jobs:
         if [ ${MACHINE_TYPE} == 'aarch64' ]; then echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/arm64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list; fi
         sudo apt-get update -y
         sudo apt-get install -y cmake gcc g++ gfortran hwloc libhwloc-dev
-        sudo apt-get install -y nvhpc-26-1
+        sudo apt-get install -y nvhpc-26-3
     - name: build and test
       run: |
         export MACHINE_TYPE=`uname -m`
-        if [ ${MACHINE_TYPE} == 'x86_64' ]; then export PATH="$PATH:/opt/nvidia/hpc_sdk/Linux_x86_64/26.1/compilers/bin"; fi
-        if [ ${MACHINE_TYPE} == 'aarch64' ]; then export PATH="$PATH:/opt/nvidia/hpc_sdk/Linux_aarch64/26.1/compilers/bin"; fi
+        if [ ${MACHINE_TYPE} == 'x86_64' ]; then export PATH="$PATH:/opt/nvidia/hpc_sdk/Linux_x86_64/26.3/compilers/bin"; fi
+        if [ ${MACHINE_TYPE} == 'aarch64' ]; then export PATH="$PATH:/opt/nvidia/hpc_sdk/Linux_aarch64/26.3/compilers/bin"; fi
         nvc --version
         for sch in nemesis sherwood distrib
         do


### PR DESCRIPTION
This does several version bumps. Most notably, it swaps out ACFL for the new ATFL toolchain from ARM. It also adds a rocky-linux-based build meant to approximate older Linux systems that are still expected to work.